### PR TITLE
Add additional contract type to ltm_1.6

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -262,6 +262,7 @@ PLUGINS_CONFIG = {
         "barchart_bar_width": float(os.environ.get("BARCHART_BAR_WIDTH", 0.1)),
         "barchart_width": int(os.environ.get("BARCHART_WIDTH", 12)),
         "barchart_height": int(os.environ.get("BARCHART_HEIGHT", 5)),
+        "additional_contract_types": ["Hardware Maintenance", "Subscription", "Software License", "Services", "Lease"],
     },
 }
 

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -262,7 +262,10 @@ PLUGINS_CONFIG = {
         "barchart_bar_width": float(os.environ.get("BARCHART_BAR_WIDTH", 0.1)),
         "barchart_width": int(os.environ.get("BARCHART_WIDTH", 12)),
         "barchart_height": int(os.environ.get("BARCHART_HEIGHT", 5)),
-        "additional_contract_types": ["Hardware Maintenance", "Subscription", "Software License", "Services", "Lease"],
+        "additional_contract_types": os.environ.get(
+            "DEVICE_LIFECYCLE_ADD_CONTRACT_TYPES",
+            "Hardware Maintenance,Subscription,Software License,Services,Lease",
+        ).split(","),
     },
 }
 

--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -72,8 +72,10 @@ sudo systemctl restart nautobot nautobot-worker nautobot-scheduler
 
 The plugin behavior can be controlled with the following list of settings.
 
-| Key     | Example | Default | Description                          |
-| ------- | ------ | -------- | ------------------------------------- |
-| enable_backup | True | True | A boolean to represent whether or not to run backup configurations within the plugin. |
-| platform_slug_map | {"cisco_wlc": "cisco_aireos"} | None | A dictionary in which the key is the platform slug and the value is what netutils uses in any "network_os" parameter. |
-| per_feature_bar_width | 0.15 | 0.15 | The width of the table bar within the overview report |
+| Key                         | Example                                        | Default | Description                                                                     |
+| --------------------------- | ---------------------------------------------- | ------- | ------------------------------------------------------------------------------- |
+| `expired_field`             | `end_of_support`                               |         | The field name representing the expiry date.                                    |
+| `barchart_bar_width`        | `0.1`                                          | `0.15`  | The width of the table bar within the overview report.                          |
+| `barchart_width`            | `12`                                           |         | The width of the barchart within the overview report.                           |
+| `barchart_height`           | `5`                                            |         | The height of the barchart within the overview report.                          |
+| `additional_contract_types` | `["Software Maintenance", "Software License"]` | `None`  | A list of contract types to append to the existing Hardware and Software types. |

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -49,6 +49,7 @@ from nautobot_device_lifecycle_mgmt.models import (
     ValidatedSoftwareLCM,
     VulnerabilityLCM,
 )
+from nautobot_device_lifecycle_mgmt.utils import add_custom_contract_types
 
 logger = logging.getLogger("nautobot_device_lifecycle_mgmt")
 
@@ -753,7 +754,9 @@ class ContractLCMForm(BootstrapMixin, CustomFieldModelFormMixin, RelationshipMod
         to_field_name="pk",
         required=True,
     )
-    contract_type = forms.ChoiceField(choices=add_blank_choice(ContractTypeChoices.CHOICES), label="Contract Type")
+    contract_type = forms.ChoiceField(
+        choices=add_blank_choice(add_custom_contract_types(ContractTypeChoices.CHOICES)), label="Contract Type"
+    )
     currency = forms.ChoiceField(
         required=False, widget=StaticSelect2, choices=add_blank_choice(CurrencyChoices.CHOICES)
     )

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -755,7 +755,7 @@ class ContractLCMForm(BootstrapMixin, CustomFieldModelFormMixin, RelationshipMod
         required=True,
     )
     contract_type = forms.ChoiceField(
-        choices=add_blank_choice(add_custom_contract_types(ContractTypeChoices.CHOICES)), label="Contract Type"
+        choices=lambda: add_blank_choice(add_custom_contract_types(ContractTypeChoices.CHOICES)), label="Contract Type"
     )
     currency = forms.ChoiceField(
         required=False, widget=StaticSelect2, choices=add_blank_choice(CurrencyChoices.CHOICES)

--- a/nautobot_device_lifecycle_mgmt/tests/test_forms.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_forms.py
@@ -1,5 +1,5 @@
 """Test forms."""
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.contrib.contenttypes.models import ContentType
 from unittest.mock import patch
 

--- a/nautobot_device_lifecycle_mgmt/tests/test_forms.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_forms.py
@@ -1,6 +1,7 @@
 """Test forms."""
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.contrib.contenttypes.models import ContentType
+from unittest.mock import patch
 
 from nautobot.dcim.models import DeviceType, Manufacturer, Device, DeviceRole, Site, InventoryItem, Platform
 from nautobot.extras.models import Status, Tag
@@ -11,6 +12,7 @@ from nautobot_device_lifecycle_mgmt.forms import (
     ValidatedSoftwareLCMForm,
     CVELCMForm,
     SoftwareImageLCMForm,
+    ContractLCMForm,
 )
 from nautobot_device_lifecycle_mgmt.models import SoftwareImageLCM, SoftwareLCM, CVELCM
 
@@ -587,3 +589,20 @@ class SoftwareImageLCMFormTest(TestCase):  # pylint: disable=no-member,too-many-
         self.assertFalse(form.is_valid())
         self.assertIn("download_url", form.errors)
         self.assertIn("Enter a valid URL.", form.errors["download_url"])
+
+
+class ContractFormTest(TestCase):
+    """Test class for Device Lifecycle Contract Form."""
+
+    def test_custom_contract_types(self):
+        form = ContractLCMForm()
+        choices = form.base_fields["contract_type"].choices  # pylint: disable=no-member
+
+        self.assertIn(("Software License", "Software License"), list(choices))
+
+    @patch("nautobot_device_lifecycle_mgmt.utils.PLUGIN_SETTINGS", {"additional_contract_types": []})
+    def test_no_custom_contract_types(self):
+        form = ContractLCMForm()
+
+        choices = form.base_fields["contract_type"].choices  # pylint: disable=no-member
+        self.assertNotIn(("Software License", "Software License"), list(choices))

--- a/nautobot_device_lifecycle_mgmt/tests/test_forms.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_forms.py
@@ -1,7 +1,7 @@
 """Test forms."""
+from unittest.mock import patch
 from django.test import TestCase
 from django.contrib.contenttypes.models import ContentType
-from unittest.mock import patch
 
 from nautobot.dcim.models import DeviceType, Manufacturer, Device, DeviceRole, Site, InventoryItem, Platform
 from nautobot.extras.models import Status, Tag

--- a/nautobot_device_lifecycle_mgmt/utils.py
+++ b/nautobot_device_lifecycle_mgmt/utils.py
@@ -1,6 +1,9 @@
 """Utility functions and classes used by the plugin."""
+from django.conf import settings
 from django.db.models import Count, Subquery, OuterRef
 from django.db.models.functions import Coalesce
+
+PLUGIN_SETTINGS = settings.PLUGINS_CONFIG["nautobot_device_lifecycle_mgmt"]
 
 
 def count_related_m2m(model, field):
@@ -8,3 +11,13 @@ def count_related_m2m(model, field):
     subquery = Subquery(model.objects.filter(**{"pk": OuterRef("pk")}).order_by().annotate(c=Count(field)).values("c"))
 
     return Coalesce(subquery, 0)
+
+
+def add_custom_contract_types(choices):
+    """Add custom defined choices to existing Contract Type choices.
+
+    Args:
+        choices (tuple): Existing Device Lifecycle Contract Type tuple.
+    """
+    defined_additional_contract_types = PLUGIN_SETTINGS.get("additional_contract_types", [])
+    return tuple((type, type) for type in defined_additional_contract_types) + tuple(choices)

--- a/nautobot_device_lifecycle_mgmt/utils.py
+++ b/nautobot_device_lifecycle_mgmt/utils.py
@@ -20,4 +20,4 @@ def add_custom_contract_types(choices):
         choices (tuple): Existing Device Lifecycle Contract Type tuple.
     """
     defined_additional_contract_types = PLUGIN_SETTINGS.get("additional_contract_types", [])
-    return tuple((type, type) for type in defined_additional_contract_types) + tuple(choices)
+    return tuple((contract_type, contract_type) for contract_type in defined_additional_contract_types) + tuple(choices)


### PR DESCRIPTION
Provides the same feature as #239 but with respect to the ltm_1.6 branch. The table in the docs was using config items from Golden Config so I changed the table to match the plugin.