### PR TITLE
Changes cost format in table view

### DIFF
--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -443,8 +443,6 @@ class ContractLCMTable(BaseTable):
         template_code="""{% load humanize %}{{ record.cost|intcomma }}{% if record.currency %} {{ record.currency }}{% endif %}"""
     )
     actions = ButtonsColumn(ContractLCM, buttons=("changelog", "edit", "delete"))
-    start = tables.DateColumn(format="m-d-Y")
-    end = tables.DateColumn(format="m-d-Y")
 
     class Meta(BaseTable.Meta):  # pylint: disable=too-few-public-methods
         """Meta attributes."""

--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -440,9 +440,11 @@ class ContractLCMTable(BaseTable):
         args=[A("provider.pk")],
     )
     cost = tables.TemplateColumn(
-        template_code="""{{ record.cost }}{% if record.currency %} {{ record.currency }}{% endif %}"""
+        template_code="""{% load humanize %}{{ record.cost|intcomma }}{% if record.currency %} {{ record.currency }}{% endif %}"""
     )
     actions = ButtonsColumn(ContractLCM, buttons=("changelog", "edit", "delete"))
+    start = tables.DateColumn(format="m-d-Y")
+    end = tables.DateColumn(format="m-d-Y")
 
     class Meta(BaseTable.Meta):  # pylint: disable=too-few-public-methods
         """Meta attributes."""


### PR DESCRIPTION
While working with a customer, two concerns came up about the format of some data in certian columns of the Contract list view. I figure I make a PR here to see if these would be welcome changes. If these are liked, I'll do the same for the 2.0 version. 

This PR does two things:
1. Comma separated cost in the "cost" column
2. Reformats the date in the "Month-Day-Year` format.
![Screenshot 2023-11-30 at 4 00 31 PM](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/assets/38091261/ea3c7c70-3d5a-4904-926d-e5b7757ae751)

