### PR TITLE
Fix bug in the nautobot_lcm_hw_end_of_support_per_part_number metric.

### DIFF
--- a/nautobot_device_lifecycle_mgmt/metrics.py
+++ b/nautobot_device_lifecycle_mgmt/metrics.py
@@ -1,7 +1,7 @@
 """Nautobot Device LCM plugin application level metrics ."""
 from datetime import datetime
 
-from django.db.models import Case, Count, F, IntegerField, OuterRef, Q, Subquery, Value, When
+from django.db.models import Count, F, IntegerField, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Coalesce
 from nautobot.dcim.models import Device, DeviceType, InventoryItem, Site
 from prometheus_client.core import GaugeMetricFamily
@@ -138,13 +138,7 @@ def metrics_lcm_hw_end_of_support():  # pylint: disable=too-many-locals
     # Generate metrics with counts for out of support devices per device type
     for part_number, model, device_count in (
         DeviceType.objects.order_by()
-        .annotate(
-            num_devices=Case(
-                When(id__in=hw_end_of_support_device_types, then=Count("instances")),
-                default=0,
-                output_field=IntegerField(),
-            )
-        )
+        .annotate(num_devices=Count("instances", filter=Q(id__in=hw_end_of_support_device_types)))
         .values_list("part_number", "model", "num_devices")
     ):
         hw_end_of_support_part_number_gauge.add_metric(


### PR DESCRIPTION
Fixes incorrect query used to generate `nautobot_lcm_hw_end_of_support_per_part_number` metric.

This fix is for ltm-1.6 train.