### PR TITLE
Fix bug in the nautobot_lcm_hw_end_of_support_per_part_number metric.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [v2.0.4] - 2023-12-15
+
+### Fixed
+- [#265](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/pull/265) - Fixes incorrect query used to generate `nautobot_lcm_hw_end_of_support_per_part_number` metric.
+
 ## [v2.0.3] - 2023-11-08
 
 ### Fixed

--- a/docs/admin/release_notes/version_2.0.md
+++ b/docs/admin/release_notes/version_2.0.md
@@ -6,6 +6,11 @@ This document describes all new features and changes in the release `2.0`. The f
 
 This release adds support for [Nautobot v2.0.0](https://github.com/nautobot/nautobot/releases/tag/v2.0.0).
 
+## [v2.0.4] - 2023-12-15
+
+### Fixed
+- [#265](https://github.com/nautobot/nautobot-plugin-device-lifecycle-mgmt/pull/265) - Fixes incorrect query used to generate `nautobot_lcm_hw_end_of_support_per_part_number` metric.
+
 ## [v2.0.3] - 2023-11-08
 
 ### Fixed

--- a/nautobot_device_lifecycle_mgmt/metrics.py
+++ b/nautobot_device_lifecycle_mgmt/metrics.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Case, Count, F, IntegerField, OuterRef, Q, Subquery, Value, When
+from django.db.models import Count, F, IntegerField, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Coalesce
 from nautobot.dcim.models import Device, DeviceType, InventoryItem, Location, LocationType
 from prometheus_client.core import GaugeMetricFamily
@@ -141,13 +141,7 @@ def metrics_lcm_hw_end_of_support():  # pylint: disable=too-many-locals
     # Generate metrics with counts for out of support devices per device type
     for part_number, model, device_count in (
         DeviceType.objects.order_by()
-        .annotate(
-            num_devices=Case(
-                When(id__in=hw_end_of_support_device_types, then=Count("devices")),
-                default=0,
-                output_field=IntegerField(),
-            )
-        )
+        .annotate(num_devices=Count("devices", filter=Q(id__in=hw_end_of_support_device_types)))
         .values_list("part_number", "model", "num_devices")
     ):
         hw_end_of_support_part_number_gauge.add_metric(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-lifecycle-mgmt"
-version = "2.0.1"
+version = "2.0.4"
 description = "Manages device lifecycles for platforms and software."
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Fixes incorrect query used to generate `nautobot_lcm_hw_end_of_support_per_part_number` metric.

This fix is for 2.0.x train.
