### PR TITLE
prepare 2.1.0 release

### DIFF
--- a/docs/admin/compatibility_matrix.md
+++ b/docs/admin/compatibility_matrix.md
@@ -2,6 +2,7 @@
 
 | Device Lifecycle Management Version | Nautobot First Support Version | Nautobot Last Support Version |
 | ------------- | -------------------- | ------------- |
+| 2.1.X         | 2.0.0                | 2.99.99       |
 | 2.0.X         | 2.0.0                | 2.99.99       |
 | 1.3.X         | 1.4.0                | 1.X.X         |
 | 1.2.X         | 1.4.0                | 1.X.X         |

--- a/docs/admin/release_notes/version_1.3.md
+++ b/docs/admin/release_notes/version_1.3.md
@@ -24,7 +24,6 @@ This release includes some of the following highlights:
 - [#196](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/196) Adds reverse relationship from device type to software image.
 - [#194](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/194) Adds table with matching ValidatedSoftware objects to the DeviceType detailed view in GUI.
 
-
 ### Removed
 - [#197](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/197) Removes compatibility code for Nautobot versions < 1.4
 

--- a/docs/admin/release_notes/version_2.1.md
+++ b/docs/admin/release_notes/version_2.1.md
@@ -1,0 +1,16 @@
+# v2.1 Release Notes
+
+This document describes all new features and changes in the release `2.0`. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+This release adds support for various improvements, bug fixes, and performance improvements.
+
+## [v2.1.0] - 2023-01-26
+
+### Changed
+- [#269](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/269) - Renaming effort to standardize on Nautobot terminology for Apps/Plugins.
+
+### Fixed
+- [#277](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/277) - Updated cve_tracking.py job in order to reduce the DB queries and the overall execution time of the Job. 
+- [#265](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/265) - Fixed incorrect query used to generate nautobot_lcm_hw_end_of_support_per_part_number metric.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-lifecycle-mgmt"
-version = "2.0.4"
+version = "2.1.0"
 description = "Manages device lifecycles for platforms and software."
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# v2.1 Release Notes

This document describes all new features and changes in the release `2.0`. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

This release adds support for various improvements, bug fixes, and performance improvements.

## [v2.1.0] - 2023-01-26

### Changed
- [#269](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/269) - Renaming effort to standardize on Nautobot terminology for Apps/Plugins.

### Fixed
- [#277](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/277) - Updated cve_tracking.py job in order to reduce the DB queries and the overall execution time of the Job. 
- [#265](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/265) - Fixed incorrect query used to generate nautobot_lcm_hw_end_of_support_per_part_number metric.
