### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## [v1.6.0] - 2024-01-26
+### Added
+- [#217](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/217) - Adds new tab "Contract devices" to the Contract details view. Adds "Contract devices" export feature to the Contract details view. Adds new tab "Contract inventory items" to the Contract details view. Adds "Contract inventory items" export feature to the Contract details view. Linting targeting Python 3.8
+
+### Fixed
+- [#275](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/275) - Updated in cve_tracking.py job in order to get the Related Software Relationships fetched from the CVELVM database query. That way we reduce the DB queries and the overall execution time of the Job.
+- [#248](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/248) - Fixes issue with number field not showing up in UI and API. Fixes model validation to match UI validation. This ensures provider and contract_type fields are set. Adds missing tests. Addresses #242.
+- [#259](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/259) - Fixes incorrect query used to generate nautobot_lcm_hw_end_of_support_per_part_number metric.
+
+
 ## [v1.3.3] - 2023-09-29
 
 ### Changed

--- a/docs/admin/compatibility_matrix.md
+++ b/docs/admin/compatibility_matrix.md
@@ -2,7 +2,8 @@
 
 | Device Lifecycle Management Version | Nautobot First Support Version | Nautobot Last Support Version |
 | ------------- | -------------------- | ------------- |
-| 1.3.X         | 1.4.0                | 1.5.X         |
+| 1.6.X         | 1.4.0                | 1.6.X         |
+| 1.3.X         | 1.4.0                | 1.6.X         |
 | 1.2.X         | 1.4.0                | 1.5.X         |
 | 1.1.X         | 1.2.0               | 1.5.9         |
 | 1.0.X         | 1.1.6               | 1.5.9         |

--- a/docs/admin/release_notes/version_1.6.md
+++ b/docs/admin/release_notes/version_1.6.md
@@ -1,0 +1,25 @@
+# v1.6 Release Notes
+
+This document describes all new features and changes in the release `1.6.X`. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+This release includes ltm1.6 support and some of the following highlights:
+
+ - Adds new tab "Contract devices" to the Contract details view.
+ - Adds "Contract devices" export feature to the Contract details view.
+ - Adds new tab "Contract inventory items" to the Contract details view.
+ - Adds "Contract inventory items" export feature to the Contract details view.
+ - Linting targeting Python 3.8
+ - Updated in cve_tracking.py job in order to get the Related Software Relationships fetched from the CVELVM database query. That way we reduce the DB queries and the overall execution time of the Job.
+ - Fixes issue with number field not showing up in UI and API. Fixes model validation to match UI validation. This ensures provider and contract_type fields are set. Adds missing tests. Addresses #242.
+ - Fixes incorrect query used to generate nautobot_lcm_hw_end_of_support_per_part_number metric.
+
+
+## [v1.6.0] - 2024-01-26
+### Added
+- [#217](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/217) - Adds new tab "Contract devices" to the Contract details view. Adds "Contract devices" export feature to the Contract details view. Adds new tab "Contract inventory items" to the Contract details view. Adds "Contract inventory items" export feature to the Contract details view. Linting targeting Python 3.8
+
+### Fixed
+- [#275](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/275) - Updated in cve_tracking.py job in order to get the Related Software Relationships fetched from the CVELVM database query. That way we reduce the DB queries and the overall execution time of the Job.
+- [#248](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/248) - Fixes issue with number field not showing up in UI and API. Fixes model validation to match UI validation. This ensures provider and contract_type fields are set. Adds missing tests. Addresses #242.
+- [#259](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/259) - Fixes incorrect query used to generate nautobot_lcm_hw_end_of_support_per_part_number metric.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-lifecycle-mgmt"
-version = "1.3.1"
+version = "1.6.0"
 description = "Manages device lifecycles for platforms and software."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Release Overview
This release includes ltm1.6 support and some of the following highlights:

 - Adds new tab "Contract devices" to the Contract details view.
 - Adds "Contract devices" export feature to the Contract details view.
 - Adds new tab "Contract inventory items" to the Contract details view.
 - Adds "Contract inventory items" export feature to the Contract details view.
 - Linting targeting Python 3.8
 - Updated in cve_tracking.py job in order to get the Related Software Relationships fetched from the CVELVM database query. That way we reduce the DB queries and the overall execution time of the Job.
 - Fixes issue with number field not showing up in UI and API. Fixes model validation to match UI validation. This ensures provider and contract_type fields are set. Adds missing tests. Addresses #242.
 - Fixes incorrect query used to generate nautobot_lcm_hw_end_of_support_per_part_number metric.


## [v1.6.0] - 2024-01-26
### Added
- [#217](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/217) - Adds new tab "Contract devices" to the Contract details view. Adds "Contract devices" export feature to the Contract details view. Adds new tab "Contract inventory items" to the Contract details view. Adds "Contract inventory items" export feature to the Contract details view. Linting targeting Python 3.8

### Fixed
- [#275](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/275) - Updated in cve_tracking.py job in order to get the Related Software Relationships fetched from the CVELVM database query. That way we reduce the DB queries and the overall execution time of the Job.
- [#248](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/248) - Fixes issue with number field not showing up in UI and API. Fixes model validation to match UI validation. This ensures provider and contract_type fields are set. Adds missing tests. Addresses #242.
- [#259](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/259) - Fixes incorrect query used to generate nautobot_lcm_hw_end_of_support_per_part_number metric.
