### PR TITLE
chore: rem. duplicated 'tasks.py' in dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,4 +24,3 @@ LICENSE
 **/*.log
 **/.vscode/
 invoke*.yml
-tasks.py


### PR DESCRIPTION
Accidentally noticed that 'tasks.py' is specified in .dockerignore twice: [L22](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/blob/b1b9cd686554484b47969bf09d3901ffeedd0dd0/.dockerignore#L22) and [L27](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/blob/b1b9cd686554484b47969bf09d3901ffeedd0dd0/.dockerignore#L27)

___

* (chore): remove duplicated 'tasks.py' in .dockerignore