### PR TITLE
Fix inventory items metric queries that use annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v2.1.1] - 2024-03-12
+
+### Fixed
+- [#313](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/313) - Fixes bug that could lead to InventoryItem metric queries erroring out.
+
+
 ## [v1.6.1] - 2024-02-04
 ### Added
 - [#287](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/287) - Adds support for Python 3.11

--- a/changes/313.fixed
+++ b/changes/313.fixed
@@ -1,0 +1,1 @@
+Fixes bug that could lead to InventoryItem metric queries erroring out.

--- a/docs/admin/release_notes/version_2.1.md
+++ b/docs/admin/release_notes/version_2.1.md
@@ -6,6 +6,11 @@ This document describes all new features and changes in the release `2.0`. The f
 
 This release adds support for various improvements, bug fixes, and performance improvements.
 
+## [v2.1.1] - 2024-03-12
+
+### Fixed
+- [#313](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/313) - Fixes bug that could lead to InventoryItem metric queries erroring out.
+
 ## [v2.1.0] - 2024-01-26
 
 ### Changed

--- a/nautobot_device_lifecycle_mgmt/metrics.py
+++ b/nautobot_device_lifecycle_mgmt/metrics.py
@@ -75,7 +75,9 @@ def metrics_lcm_validation_report_inventory_item():
         "Number of devices that have valid/invalid software by inventory item",
         labels=["inventory_item", "is_valid"],
     )
-    inventory_item_part_ids = InventoryItem.objects.exclude(part_id="").order_by().values("part_id").distinct()
+    inventory_item_part_ids = (
+        InventoryItem.objects.exclude(part_id="").without_tree_fields().order_by().values("part_id").distinct()
+    )
 
     # Annotate InventoryItemSoftwareValidationResult with counts for valid and invalid software per part id
     validation_counts = (
@@ -150,7 +152,8 @@ def metrics_lcm_hw_end_of_support():  # pylint: disable=too-many-locals
 
     # Generate metrics with counts for out of support inventory items per part id
     for part_id, inv_item_count in (
-        InventoryItem.objects.order_by()
+        InventoryItem.objects.without_tree_fields()
+        .order_by()
         .filter(part_id__in=hw_end_of_support_invitems)
         .values("part_id")
         .annotate(inv_item_count=Count("id"))
@@ -196,7 +199,8 @@ def metrics_lcm_hw_end_of_support():  # pylint: disable=too-many-locals
     )
     # Get count of out of hw support inventory items per location
     hw_end_of_support_per_location_invitems = (
-        InventoryItem.objects.order_by()
+        InventoryItem.objects.without_tree_fields()
+        .order_by()
         .filter(part_id__in=hw_end_of_support_invitems)
         .values(location_name=F("device__location__name"))
         .annotate(location_count=Count("id"))

--- a/nautobot_device_lifecycle_mgmt/tests/conftest.py
+++ b/nautobot_device_lifecycle_mgmt/tests/conftest.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from nautobot.dcim.models import Device, DeviceType, InventoryItem, Location, LocationType, Manufacturer, Platform
 from nautobot.extras.models import Role, Status
 
-from nautobot_device_lifecycle_mgmt.models import CVELCM, SoftwareLCM, ValidatedSoftwareLCM
+from nautobot_device_lifecycle_mgmt.models import CVELCM, HardwareLCM, SoftwareLCM, ValidatedSoftwareLCM
 
 
 def create_devices():
@@ -160,3 +160,34 @@ def create_validated_softwares():
     )
 
     return validated_items
+
+
+def create_inventory_item_hardware_notices():
+    """Create inventory item hardware notices for tests."""
+
+    return (
+        HardwareLCM.objects.create(
+            inventory_item="VS-S2T-10G",
+            end_of_sale=date(2022, 4, 1),
+            end_of_support=date(2023, 4, 1),
+            end_of_sw_releases=date(2024, 4, 1),
+            end_of_security_patches=date(2025, 4, 1),
+            documentation_url="https://test.com",
+        ),
+        HardwareLCM.objects.create(
+            inventory_item="QSFP-100G-SR4-S",
+            end_of_sale=date(2022, 4, 1),
+            end_of_support=date(2024, 1, 1),
+            end_of_sw_releases=date(2024, 4, 1),
+            end_of_security_patches=date(2025, 4, 1),
+            documentation_url="https://test.com",
+        ),
+        HardwareLCM.objects.create(
+            inventory_item="WS-X6548-GE-TX",
+            end_of_sale=date(2022, 4, 1),
+            end_of_support=date(2999, 1, 1),
+            end_of_sw_releases=date(2024, 4, 1),
+            end_of_security_patches=date(2025, 4, 1),
+            documentation_url="https://test.com",
+        ),
+    )

--- a/nautobot_device_lifecycle_mgmt/tests/test_metrics.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_metrics.py
@@ -1,0 +1,104 @@
+"""nautobot_device_lifecycle_mgmt test class for metrics."""
+from django.db import ProgrammingError
+from nautobot.core.testing import TestCase
+
+from nautobot_device_lifecycle_mgmt.metrics import (
+    metrics_lcm_hw_end_of_support,
+    metrics_lcm_validation_report_device_type,
+    metrics_lcm_validation_report_inventory_item,
+)
+
+from .conftest import create_devices, create_inventory_item_hardware_notices, create_inventory_items
+
+
+class MetricsTest(TestCase):
+    """Test class for Device Lifecycle metrics."""
+
+    def setUp(self):
+        create_inventory_items()
+        create_inventory_item_hardware_notices()
+
+    def test_metrics_lcm_validation_report_device_type(self):
+        """Test metric device_software_compliance_gauge."""
+        create_devices()
+        # TODO: Generate DeviceSoftwareValidationResult
+        metric_gen = metrics_lcm_validation_report_device_type()
+        metric = next(metric_gen)
+
+        expected_ts_samples = {
+            (("device_type", "6509-E"), ("is_valid", "False")): 0,
+            (("device_type", "6509-E"), ("is_valid", "True")): 0,
+        }
+
+        for sample in metric.samples:
+            sample_labels = tuple(sample.labels.items())
+            self.assertEqual(expected_ts_samples[sample_labels], sample.value)
+
+    def test_metrics_lcm_validation_report_inventory_item(self):
+        """Test metric inventory_item_software_compliance_gauge."""
+        # TODO: Generate InventoryItemSoftwareValidationResult
+        metric_gen = metrics_lcm_validation_report_inventory_item()
+        metric = next(metric_gen)
+
+        expected_ts_samples = {
+            (("inventory_item", "VS-S2T-10G"), ("is_valid", "False")): 0,
+            (("inventory_item", "QSFP-100G-SR4-S"), ("is_valid", "False")): 0,
+            (("inventory_item", "WS-X6548-GE-TX"), ("is_valid", "False")): 0,
+            (("inventory_item", "VS-S2T-10G"), ("is_valid", "True")): 0,
+            (("inventory_item", "QSFP-100G-SR4-S"), ("is_valid", "True")): 0,
+            (("inventory_item", "WS-X6548-GE-TX"), ("is_valid", "True")): 0,
+        }
+
+        for sample in metric.samples:
+            sample_labels = tuple(sample.labels.items())
+            self.assertEqual(expected_ts_samples[sample_labels], sample.value)
+
+    def test_metrics_lcm_hw_end_of_support_does_not_error(self):
+        """Query providing data to hw_end_of_support_location_gauge metric should not error out.
+        Guards against https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/309
+        """
+        metric_gen = metrics_lcm_hw_end_of_support()
+        # skip hw_end_of_support_part_number_gauge
+        next(metric_gen)
+        try:
+            # Get hw_end_of_support_location_gauge
+            next(metric_gen)
+        except ProgrammingError:
+            self.fail("hw_end_of_support_location_gauge query bug")
+
+    def test_metrics_lcm_hw_end_of_support_part_number(self):
+        """Test metric hw_end_of_support_part_number_gauge."""
+        metric_gen = metrics_lcm_hw_end_of_support()
+
+        # Get hw_end_of_support_part_number_gauge
+        metric = next(metric_gen)
+
+        expected_ts_samples = {
+            ("part_number", "6509-E"): 0,
+            ("part_number", "VS-S2T-10G"): 1,
+            ("part_number", "QSFP-100G-SR4-S"): 1,
+            ("part_number", "WS-X6548-GE-TX"): 0,
+        }
+
+        for sample in metric.samples:
+            sample_labels = tuple(sample.labels.items())[0]
+            self.assertEqual(expected_ts_samples[sample_labels], sample.value)
+
+    def test_metrics_lcm_hw_end_of_support_location(self):
+        """Test metric hw_end_of_support_location_gauge."""
+        metric_gen = metrics_lcm_hw_end_of_support()
+
+        # skip hw_end_of_support_part_number_gauge
+        next(metric_gen)
+
+        # Get hw_end_of_support_location_gauge
+        metric = next(metric_gen)
+
+        expected_ts_samples = {
+            ("location", "Location1"): 2,
+            ("location", "Location2"): 0,
+        }
+
+        for sample in metric.samples:
+            sample_labels = tuple(sample.labels.items())[0]
+            self.assertEqual(expected_ts_samples[sample_labels], sample.value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-lifecycle-mgmt"
-version = "2.1.0"
+version = "2.1.1"
 description = "Manages device lifecycles for platforms and software."
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
- Fixes inventory items metric queries that use annotations. These use `TreeQuerySet` which needs `without_tree_fields()` to remove default ordering.
- Add test coverage for metric generator functions.

Fixes #309 