### PR TITLE
prepare release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - [#313](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/313) - Fixed bug that could lead to InventoryItem metric queries erroring out.
-- [299](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/299) - Fixed Order for 1.6.1 release notes in admin file so most recent is at the top
+- [#299](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/299) - Fixed Order for 1.6.1 release notes in admin file so most recent is at the top
 - [#306](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/306) - Fixed Provider field in Contract Bulk Edit Form
 - [#320](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/320) - Fixed location of views for upstream Nautobot 2.2 tests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # CHANGELOG
 
-## [v2.1.1] - 2024-03-12
+## [v2.1.1] - 2024-04-08
 
 ### Fixed
-- [#313](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/313) - Fixes bug that could lead to InventoryItem metric queries erroring out.
+- [#313](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/313) - Fixed bug that could lead to InventoryItem metric queries erroring out.
+- [299](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/299) - Fixed Order for 1.6.1 release notes in admin file so most recent is at the top
+- [#306](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/306) - Fixed Provider field in Contract Bulk Edit Form
+- [#320](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/320) - Fixed location of views for upstream Nautobot 2.2 tests.
+
+### Changed
+- [#289](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/289)  - Replaced pydocstyle with ruff.
+
+### Housekeeping
+- [#310](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/310) - Re-baked from the latest template.
 
 
 ## [v1.6.1] - 2024-02-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Housekeeping
 - [#310](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/310) - Re-baked from the latest template.
+- [#323](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/310) - prepare for 2.1.1 release and fix doc builds.
 
 
 ## [v1.6.1] - 2024-02-04

--- a/changes/289.changed
+++ b/changes/289.changed
@@ -1,1 +1,0 @@
-Replaced pydocstyle with ruff.

--- a/changes/299.fixed
+++ b/changes/299.fixed
@@ -1,1 +1,0 @@
-Fixed: Order for 1.6.1 release notes in admin file so most recent is at the top

--- a/changes/306.fixed
+++ b/changes/306.fixed
@@ -1,1 +1,0 @@
-Fixed Provider field in Contract Bulk Edit Form

--- a/changes/313.fixed
+++ b/changes/313.fixed
@@ -1,1 +1,0 @@
-Fixes bug that could lead to InventoryItem metric queries erroring out.

--- a/changes/320.fixed
+++ b/changes/320.fixed
@@ -1,1 +1,0 @@
-Fixed location of views for upstream Nautobot 2.2 tests.

--- a/changes/323.housekeeping
+++ b/changes/323.housekeeping
@@ -1,0 +1,1 @@
+prepare for 2.1.1 release and fix doc builds.

--- a/changes/8.housekeeping
+++ b/changes/8.housekeeping
@@ -1,1 +1,0 @@
-Re-baked from the latest template.

--- a/docs/admin/release_notes/version_2.1.md
+++ b/docs/admin/release_notes/version_2.1.md
@@ -10,7 +10,7 @@ This release adds support for various improvements, bug fixes, and performance i
 
 ### Fixed
 - [#313](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/313) - Fixed bug that could lead to InventoryItem metric queries erroring out.
-- [299](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/299) - Fixed Order for 1.6.1 release notes in admin file so most recent is at the top
+- [#299](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/299) - Fixed Order for 1.6.1 release notes in admin file so most recent is at the top
 - [#306](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/306) - Fixed Provider field in Contract Bulk Edit Form
 - [#320](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/320) - Fixed location of views for upstream Nautobot 2.2 tests.
 

--- a/docs/admin/release_notes/version_2.1.md
+++ b/docs/admin/release_notes/version_2.1.md
@@ -1,15 +1,25 @@
 # v2.1 Release Notes
 
-This document describes all new features and changes in the release `2.0`. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This document describes all new features and changes in the release `2.1`. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Release Overview
 
 This release adds support for various improvements, bug fixes, and performance improvements.
 
-## [v2.1.1] - 2024-03-12
+## [v2.1.1] - 2024-04-08
 
 ### Fixed
-- [#313](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/313) - Fixes bug that could lead to InventoryItem metric queries erroring out.
+- [#313](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/313) - Fixed bug that could lead to InventoryItem metric queries erroring out.
+- [299](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/299) - Fixed Order for 1.6.1 release notes in admin file so most recent is at the top
+- [#306](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/306) - Fixed Provider field in Contract Bulk Edit Form
+- [#320](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/320) - Fixed location of views for upstream Nautobot 2.2 tests.
+
+### Changed
+- [#289](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/289)  - Replaced pydocstyle with ruff.
+
+### Housekeeping
+- [#310](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/310) - Re-baked from the latest template.
+
 
 ## [v2.1.0] - 2024-01-26
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,9 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v2.1: "admin/release_notes/version_2.1.md"
+          - v2.0: "admin/release_notes/version_2.0.md"
+          - v1.6: "admin/release_notes/version_1.6.md"
           - v1.3: "admin/release_notes/version_1.3.md"
           - v1.2: "admin/release_notes/version_1.2.md"
           - v1.1: "admin/release_notes/version_1.1.md"


### PR DESCRIPTION
## [v2.1.1] - 2024-04-08

### Fixed
- [#313](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/313) - Fixed bug that could lead to InventoryItem metric queries erroring out.
- [#299](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/299) - Fixed Order for 1.6.1 release notes in admin file so most recent is at the top
- [#306](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/306) - Fixed Provider field in Contract Bulk Edit Form
- [#320](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/320) - Fixed location of views for upstream Nautobot 2.2 tests.

### Changed
- [#289](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/289)  - Replaced pydocstyle with ruff.

### Housekeeping
- [#310](https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/pull/310) - Re-baked from the latest template.

