### PR TITLE
[2.x] Allow metrics to be enabled selectively and disable all by default.

### DIFF
--- a/changes/325.added
+++ b/changes/325.added
@@ -1,0 +1,1 @@
+Added `enabled_metrics` setting to allow selective enabling of metrics.

--- a/changes/325.changed
+++ b/changes/325.changed
@@ -1,0 +1,1 @@
+DLM metrics are now disabled by default.

--- a/development/development.env
+++ b/development/development.env
@@ -36,3 +36,5 @@ POSTGRES_DB=${NAUTOBOT_DB_NAME}
 MYSQL_USER=${NAUTOBOT_DB_USER}
 MYSQL_DATABASE=${NAUTOBOT_DB_NAME}
 MYSQL_ROOT_HOST=%
+
+NAUTOBOT_DLM_ENABLED_METRICS = "nautobot_lcm_software_compliance_per_device_type,nautobot_lcm_software_compliance_per_inventory_item,nautobot_lcm_hw_end_of_support_per_part_number,nautobot_lcm_hw_end_of_support_per_location"

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -135,5 +135,6 @@ PLUGINS_CONFIG = {
         "barchart_bar_width": float(os.environ.get("BARCHART_BAR_WIDTH", 0.1)),
         "barchart_width": int(os.environ.get("BARCHART_WIDTH", 12)),
         "barchart_height": int(os.environ.get("BARCHART_HEIGHT", 5)),
+        "enabled_metrics": [x for x in os.environ.get("NAUTOBOT_DLM_ENABLED_METRICS", "").split(",") if x],
     },
 }

--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -69,9 +69,23 @@ sudo systemctl restart nautobot nautobot-worker nautobot-scheduler
 ## App Configuration
 
 The app behavior can be controlled with the following list of settings:
-| Key                  | Example                   | Default | Description                                                          |
-| -------------------- | ------------------------- | ------- | -------------------------------------------------------------------- |
-| `expired_field`      | `end_of_support`          |         | The field name representing the expiry date.                          |
-| `barchart_bar_width` | `0.1`                     | `0.15`  | The width of the table bar within the overview report.                |
-| `barchart_width`     | `12`                      |         | The width of the barchart within the overview report.                 |
-| `barchart_height`    | `5`                       |         | The height of the barchart within the overview report.                |
+
+| Key                  | ENV VAR | Example                   | Default | Description |
+| -------------------- | ------- |  ------------------------- | ------- | -------------------------------------------------------------------- |
+| `expired_field`      | `NAUTOBOT_DLM_EXPIRED_FIELD` | `end_of_support`          |    `end_of_support`     | The field name representing the expiry date.                          |
+| `barchart_bar_width` | `BARCHART_BAR_WIDTH` |  `0.1`                     | `0.15`  | The width of the table bar within the overview report.                |
+| `barchart_width`     | `BARCHART_WIDTH` | `12`                      |   `12`     | The width of the barchart within the overview report.                 |
+| `barchart_height`    | `BARCHART_HEIGHT` | `5`                       |   `5`      | The height of the barchart within the overview report.                |
+| `enabled_metrics`    | `NAUTOBOT_DLM_ENABLED_METRICS` | `["nautobot_lcm_hw_end_of_support_per_location"]`                        | `[]`               | Enables metrics corresponding to the provided, comma separated, entries.               |
+
+### Available Metric Names
+
+Following are the metric names that can be defined in `enabled_metrics`:
+
+- `nautobot_lcm_software_compliance_per_device_type`: Number of devices with valid/invalid software by device_type.
+
+- `nautobot_lcm_software_compliance_per_inventory_item`: Number of inventory items with valid/invalid software.
+
+- `nautobot_lcm_hw_end_of_support_per_part_number`: Number of End of Support devices and inventory items per Part Number.
+
+- `nautobot_lcm_hw_end_of_support_per_location`: Number of End of Support devices and inventory items per Location.

--- a/nautobot_device_lifecycle_mgmt/__init__.py
+++ b/nautobot_device_lifecycle_mgmt/__init__.py
@@ -25,6 +25,7 @@ class NautobotDeviceLifecycleManagementConfig(NautobotAppConfig):
         "barchart_bar_width": 0.1,
         "barchart_width": 12,
         "barchart_height": 5,
+        "enabled_metrics": [],
     }
     caching_config = {}
     docs_view_name = "plugins:nautobot_device_lifecycle_mgmt:docs"

--- a/nautobot_device_lifecycle_mgmt/metrics.py
+++ b/nautobot_device_lifecycle_mgmt/metrics.py
@@ -1,6 +1,7 @@
 """Nautobot Device LCM App application level metrics ."""
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, F, IntegerField, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Coalesce
@@ -12,6 +13,8 @@ from nautobot_device_lifecycle_mgmt.models import (
     HardwareLCM,
     InventoryItemSoftwareValidationResult,
 )
+
+PLUGIN_CFG = settings.PLUGINS_CONFIG["nautobot_device_lifecycle_mgmt"]
 
 
 def metrics_lcm_validation_report_device_type():
@@ -114,8 +117,8 @@ def metrics_lcm_validation_report_inventory_item():
     yield inventory_item_software_compliance_gauge
 
 
-def metrics_lcm_hw_end_of_support():  # pylint: disable=too-many-locals
-    """Calculate number of End of Support devices and inventory items per Part Number and per Location.
+def metrics_lcm_hw_end_of_support_part_number():  # pylint: disable=too-many-locals
+    """Calculate number of End of Support devices and inventory items per Part Number.
 
     Yields:
         GaugeMetricFamily: Prometheus Metrics
@@ -124,11 +127,6 @@ def metrics_lcm_hw_end_of_support():  # pylint: disable=too-many-locals
         "nautobot_lcm_hw_end_of_support_per_part_number",
         "Nautobot LCM Hardware End of Support per Part Number",
         labels=["part_number"],
-    )
-    hw_end_of_support_location_gauge = GaugeMetricFamily(
-        "nautobot_lcm_hw_end_of_support_per_location",
-        "Nautobot LCM Hardware End of Support per Location",
-        labels=["location"],
     )
 
     today = datetime.today().date()
@@ -183,6 +181,27 @@ def metrics_lcm_hw_end_of_support():  # pylint: disable=too-many-locals
 
     yield hw_end_of_support_part_number_gauge
 
+
+def metrics_lcm_hw_end_of_support_location():  # pylint: disable=too-many-locals
+    """Calculate number of End of Support devices and inventory items per Location.
+
+    Yields:
+        GaugeMetricFamily: Prometheus Metrics
+    """
+    hw_end_of_support_location_gauge = GaugeMetricFamily(
+        "nautobot_lcm_hw_end_of_support_per_location",
+        "Nautobot LCM Hardware End of Support per Location",
+        labels=["location"],
+    )
+
+    today = datetime.today().date()
+    hw_end_of_support = HardwareLCM.objects.filter(end_of_support__lt=today)
+    hw_end_of_support_device_types = hw_end_of_support.exclude(device_type__isnull=True).values_list(
+        "device_type", flat=True
+    )
+    hw_end_of_support_invitems = hw_end_of_support.exclude(inventory_item__isnull=True).values_list(
+        "inventory_item", flat=True
+    )
     # Initialize per location count to 0 for all locations
     device_location_types = LocationType.objects.filter(content_types=ContentType.objects.get_for_model(Device))
     init_location_counts = (
@@ -228,8 +247,12 @@ def metrics_lcm_hw_end_of_support():  # pylint: disable=too-many-locals
     yield hw_end_of_support_location_gauge
 
 
-metrics = [
-    metrics_lcm_hw_end_of_support,
-    metrics_lcm_validation_report_device_type,
-    metrics_lcm_validation_report_inventory_item,
-]
+metrics = []
+if "nautobot_lcm_software_compliance_per_device_type" in PLUGIN_CFG["enabled_metrics"]:
+    metrics.append(metrics_lcm_validation_report_device_type)
+if "nautobot_lcm_software_compliance_per_inventory_item" in PLUGIN_CFG["enabled_metrics"]:
+    metrics.append(metrics_lcm_validation_report_inventory_item)
+if "nautobot_lcm_hw_end_of_support_per_part_number" in PLUGIN_CFG["enabled_metrics"]:
+    metrics.append(metrics_lcm_hw_end_of_support_part_number)
+if "nautobot_lcm_hw_end_of_support_per_location" in PLUGIN_CFG["enabled_metrics"]:
+    metrics.append(metrics_lcm_hw_end_of_support_location)

--- a/nautobot_device_lifecycle_mgmt/tests/test_metrics.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_metrics.py
@@ -3,7 +3,8 @@ from django.db import ProgrammingError
 from nautobot.core.testing import TestCase
 
 from nautobot_device_lifecycle_mgmt.metrics import (
-    metrics_lcm_hw_end_of_support,
+    metrics_lcm_hw_end_of_support_part_number,
+    metrics_lcm_hw_end_of_support_location,
     metrics_lcm_validation_report_device_type,
     metrics_lcm_validation_report_inventory_item,
 )
@@ -53,22 +54,20 @@ class MetricsTest(TestCase):
             sample_labels = tuple(sample.labels.items())
             self.assertEqual(expected_ts_samples[sample_labels], sample.value)
 
-    def test_metrics_lcm_hw_end_of_support_does_not_error(self):
+    def test_metrics_lcm_hw_end_of_support_location_does_not_error(self):
         """Query providing data to hw_end_of_support_location_gauge metric should not error out.
         Guards against https://github.com/nautobot/nautobot-app-device-lifecycle-mgmt/issues/309
         """
-        metric_gen = metrics_lcm_hw_end_of_support()
-        # skip hw_end_of_support_part_number_gauge
-        next(metric_gen)
+        metric_gen = metrics_lcm_hw_end_of_support_location()
         try:
             # Get hw_end_of_support_location_gauge
             next(metric_gen)
         except ProgrammingError:
-            self.fail("hw_end_of_support_location_gauge query bug")
+            self.fail("metrics_lcm_hw_end_of_support_location query bug")
 
     def test_metrics_lcm_hw_end_of_support_part_number(self):
         """Test metric hw_end_of_support_part_number_gauge."""
-        metric_gen = metrics_lcm_hw_end_of_support()
+        metric_gen = metrics_lcm_hw_end_of_support_part_number()
 
         # Get hw_end_of_support_part_number_gauge
         metric = next(metric_gen)
@@ -86,10 +85,7 @@ class MetricsTest(TestCase):
 
     def test_metrics_lcm_hw_end_of_support_location(self):
         """Test metric hw_end_of_support_location_gauge."""
-        metric_gen = metrics_lcm_hw_end_of_support()
-
-        # skip hw_end_of_support_part_number_gauge
-        next(metric_gen)
+        metric_gen = metrics_lcm_hw_end_of_support_location()
 
         # Get hw_end_of_support_location_gauge
         metric = next(metric_gen)


### PR DESCRIPTION
- Disable DLM metric generation by DEFAULT.
- Allows enabling metrics selectively by specifying the corresponding name.

