### PR TITLE
Updated template extensions to align with standard Nautobot UI views.

### DIFF
--- a/changes/261.changed
+++ b/changes/261.changed
@@ -1,0 +1,1 @@
+Updated template extensions to align with standard Nautobot UI views.

--- a/changes/261.housekeeping
+++ b/changes/261.housekeeping
@@ -1,0 +1,1 @@
+Added management command `generate_app_test_data` to generate sample data for development environments.

--- a/docs/dev/dev_environment.md
+++ b/docs/dev/dev_environment.md
@@ -482,3 +482,17 @@ invoke generate-app-config-schema
 ```
 
 This command can only guess the schema, so it's up to the developer to manually update the schema as needed.
+
+### Test Data Generation
+
+To quickly generate test data for developing against this app, you can use the following command:
+
+!!! danger
+    The `--flush` flag will completely empty your database and replace it with test data. This command should never be run in a production environment.
+
+```bash
+nautobot-server generate_app_test_data --flush
+nautobot-server createsuperuser
+```
+
+This uses the [`generate_test_data`](https://docs.nautobot.com/projects/core/en/stable/user-guide/administration/tools/nautobot-server/#generate_test_data) management command from Nautobot core to generate the Statuses, Platforms, Device Types, Devices, etc. Nautobot version 2.2.0 is the minimum version required for devices to be generated.

--- a/docs/dev/dev_environment.md
+++ b/docs/dev/dev_environment.md
@@ -485,14 +485,15 @@ This command can only guess the schema, so it's up to the developer to manually 
 
 ### Test Data Generation
 
-To quickly generate test data for developing against this app, you can use the following command:
+To quickly generate test data for developing against this app, you can use the following commands:
+
+```bash
+nautobot-server generate_test_data --flush
+nautobot-server generate_dlm_test_data
+nautobot-server createsuperuser
+```
 
 !!! danger
     The `--flush` flag will completely empty your database and replace it with test data. This command should never be run in a production environment.
 
-```bash
-nautobot-server generate_app_test_data --flush
-nautobot-server createsuperuser
-```
-
-This uses the [`generate_test_data`](https://docs.nautobot.com/projects/core/en/stable/user-guide/administration/tools/nautobot-server/#generate_test_data) management command from Nautobot core to generate the Statuses, Platforms, Device Types, Devices, etc. Nautobot version 2.2.0 is the minimum version required for devices to be generated.
+This uses the [`generate_test_data`](https://docs.nautobot.com/projects/core/en/stable/user-guide/administration/tools/nautobot-server/#generate_test_data) management command from Nautobot core to generate the Statuses, Platforms, Device Types, Devices, etc. Nautobot version 2.2.0 is the minimum version required for devices to be generated. If using an older version of Nautobot, you'll need to create devices manually after running `nautobot-server generate_test_data`.

--- a/nautobot_device_lifecycle_mgmt/management/commands/generate_app_test_data.py
+++ b/nautobot_device_lifecycle_mgmt/management/commands/generate_app_test_data.py
@@ -1,0 +1,137 @@
+"""Generate test data for the Golden Config app."""
+
+import random
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.db import DEFAULT_DB_ALIAS
+from nautobot.core.factory import get_random_instances
+from nautobot.dcim.models import Device, DeviceType, InventoryItem, Platform
+
+from nautobot_device_lifecycle_mgmt.choices import CVESeverityChoices
+from nautobot_device_lifecycle_mgmt.models import (
+    CVELCM,
+    ContactLCM,
+    ContractLCM,
+    DeviceSoftwareValidationResult,
+    HardwareLCM,
+    InventoryItemSoftwareValidationResult,
+    ProviderLCM,
+    SoftwareImageLCM,
+    SoftwareLCM,
+    ValidatedSoftwareLCM,
+    VulnerabilityLCM,
+)
+
+
+class Command(BaseCommand):
+    """Populate the database with various data as a baseline for testing (automated or manual)."""
+
+    help = __doc__
+
+    def add_arguments(self, parser):  # noqa: D102
+        parser.add_argument(
+            "--flush",
+            action="store_true",
+            help="Flush any existing data from the database before generating new data.",
+        )
+        parser.add_argument(
+            "--database",
+            default=DEFAULT_DB_ALIAS,
+            help='The database to generate the test data in. Defaults to the "default" database.',
+        )
+
+    def _generate_static_data(self):
+        devices = get_random_instances(Device, minimum=2, maximum=4)
+        device_types = get_random_instances(DeviceType, minimum=2, maximum=4)
+        inventory_items = get_random_instances(InventoryItem, minimum=2, maximum=4)
+        platforms = get_random_instances(Platform, minimum=2, maximum=4)
+
+        # create HardwareLCM
+        for device_type in device_types:
+            HardwareLCM.objects.create(device_type=device_type, end_of_sale="2022-03-14")
+        for inventory_item in inventory_items:
+            HardwareLCM.objects.create(inventory_item=inventory_item, end_of_support="2020-05-04")
+
+        # create SoftwareLCM
+        for platform in platforms:
+            SoftwareLCM.objects.create(
+                device_platform=platform,
+                version=f"Test SoftwareLCM for {platform.name}",
+            )
+
+        # create SoftwareImageLCM
+        for software in SoftwareLCM.objects.all():
+            SoftwareImageLCM.objects.create(
+                software=software,
+                image_file_name=f"{software.device_platform.name}_vxyz.bin",
+            )
+
+        # create ValidatedSoftwareLCM
+        for software in SoftwareLCM.objects.all():
+            ValidatedSoftwareLCM.objects.create(
+                software=software,
+                start="2020-01-01",
+                end="2020-12-31",
+            )
+
+        # create DeviceSoftwareValidationResult
+        software_choices = list(SoftwareLCM.objects.all())
+        for device in devices:
+            DeviceSoftwareValidationResult.objects.create(
+                device=device,
+                software=random.choice(software_choices),  # noqa: S311
+            )
+
+        # create InventoryItemSoftwareValidationResult
+        for inventory_item in inventory_items:
+            InventoryItemSoftwareValidationResult.objects.create(
+                inventory_item=inventory_item,
+                software=random.choice(software_choices),  # noqa: S311
+            )
+
+        # create ProviderLCM
+        for i in range(1, 9):
+            ProviderLCM.objects.create(
+                name=f"Test Provider {i}",
+                description=f"Description for Provider {i}",
+            )
+
+        # create ContractLCM
+        for provider in ProviderLCM.objects.all():
+            ContractLCM.objects.create(
+                provider=provider,
+                name=f"Test Contract for {provider.name}",
+            )
+
+        # create ContactLCM
+        for contract in ContractLCM.objects.all():
+            ContactLCM.objects.create(
+                contract=contract,
+                name=f"Test Contact for {contract.name}",
+            )
+
+        # create CVELCM
+        for i in range(1, 5):
+            cve = CVELCM.objects.create(
+                name=f"Test CVELCM {i}",
+                published_date="2020-01-01",
+                link="http://cve.example.org/{i}/details/",
+                severity=random.choice(CVESeverityChoices.values()),  # noqa: S311
+            )
+            cve.affected_softwares.set(get_random_instances(SoftwareLCM, minimum=1))
+
+        # create VulnerabilityLCM
+        VulnerabilityLCM.objects.create(cve=CVELCM.objects.get(name="Test CVELCM 1"))
+        VulnerabilityLCM.objects.create(software=SoftwareLCM.objects.first())
+        VulnerabilityLCM.objects.create(device=Device.objects.first())
+        VulnerabilityLCM.objects.create(inventory_item=InventoryItem.objects.first())
+
+    def handle(self, *args, **options):
+        """Entry point to the management command."""
+        # Call nautobot core's generate_test_data command to generate data for core models
+        call_command("generate_test_data", flush=options["flush"])
+
+        self._generate_static_data()
+
+        self.stdout.write(self.style.SUCCESS(f"Database {options['database']} populated with app data successfully!"))

--- a/nautobot_device_lifecycle_mgmt/management/commands/generate_dlm_test_data.py
+++ b/nautobot_device_lifecycle_mgmt/management/commands/generate_dlm_test_data.py
@@ -1,4 +1,4 @@
-"""Generate test data for the Golden Config app."""
+"""Generate test data for the Device Lifecycle Management app."""
 
 import random
 

--- a/nautobot_device_lifecycle_mgmt/management/commands/generate_dlm_test_data.py
+++ b/nautobot_device_lifecycle_mgmt/management/commands/generate_dlm_test_data.py
@@ -31,89 +31,84 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):  # noqa: D102
         parser.add_argument(
-            "--flush",
-            action="store_true",
-            help="Flush any existing data from the database before generating new data.",
-        )
-        parser.add_argument(
             "--database",
             default=DEFAULT_DB_ALIAS,
             help='The database to generate the test data in. Defaults to the "default" database.',
         )
 
-    def _generate_static_data(self):
-        devices = get_random_instances(Device, minimum=2, maximum=4)
-        device_types = get_random_instances(DeviceType, minimum=2, maximum=4)
-        inventory_items = get_random_instances(InventoryItem, minimum=2, maximum=4)
-        platforms = get_random_instances(Platform, minimum=2, maximum=4)
+    def _generate_static_data(self, db):
+        devices = get_random_instances(Device.objects.using(db), minimum=2, maximum=4)
+        device_types = get_random_instances(DeviceType.objects.using(db), minimum=2, maximum=4)
+        inventory_items = get_random_instances(InventoryItem.objects.using(db), minimum=2, maximum=4)
+        platforms = get_random_instances(Platform.objects.using(db), minimum=2, maximum=4)
 
         # create HardwareLCM
         for device_type in device_types:
-            HardwareLCM.objects.create(device_type=device_type, end_of_sale="2022-03-14")
+            HardwareLCM.objects.using(db).create(device_type=device_type, end_of_sale="2022-03-14")
         for inventory_item in inventory_items:
-            HardwareLCM.objects.create(inventory_item=inventory_item, end_of_support="2020-05-04")
+            HardwareLCM.objects.using(db).create(inventory_item=inventory_item, end_of_support="2020-05-04")
 
         # create SoftwareLCM
         for platform in platforms:
-            SoftwareLCM.objects.create(
+            SoftwareLCM.objects.using(db).create(
                 device_platform=platform,
                 version=f"Test SoftwareLCM for {platform.name}",
             )
 
         # create SoftwareImageLCM
-        for software in SoftwareLCM.objects.all():
-            SoftwareImageLCM.objects.create(
+        for software in SoftwareLCM.objects.using(db).all():
+            SoftwareImageLCM.objects.using(db).create(
                 software=software,
                 image_file_name=f"{software.device_platform.name}_vxyz.bin",
             )
 
         # create ValidatedSoftwareLCM
-        for software in SoftwareLCM.objects.all():
-            ValidatedSoftwareLCM.objects.create(
+        for software in SoftwareLCM.objects.using(db).all():
+            ValidatedSoftwareLCM.objects.using(db).create(
                 software=software,
                 start="2020-01-01",
                 end="2020-12-31",
             )
 
         # create DeviceSoftwareValidationResult
-        software_choices = list(SoftwareLCM.objects.all())
+        software_choices = list(SoftwareLCM.objects.using(db).all())
         for device in devices:
-            DeviceSoftwareValidationResult.objects.create(
+            DeviceSoftwareValidationResult.objects.using(db).create(
                 device=device,
                 software=random.choice(software_choices),  # noqa: S311
             )
 
         # create InventoryItemSoftwareValidationResult
         for inventory_item in inventory_items:
-            InventoryItemSoftwareValidationResult.objects.create(
+            InventoryItemSoftwareValidationResult.objects.using(db).create(
                 inventory_item=inventory_item,
                 software=random.choice(software_choices),  # noqa: S311
             )
 
         # create ProviderLCM
         for i in range(1, 9):
-            ProviderLCM.objects.create(
+            ProviderLCM.objects.using(db).create(
                 name=f"Test Provider {i}",
                 description=f"Description for Provider {i}",
             )
 
         # create ContractLCM
-        for provider in ProviderLCM.objects.all():
-            ContractLCM.objects.create(
+        for provider in ProviderLCM.objects.using(db).all():
+            ContractLCM.objects.using(db).create(
                 provider=provider,
                 name=f"Test Contract for {provider.name}",
             )
 
         # create ContactLCM
-        for contract in ContractLCM.objects.all():
-            ContactLCM.objects.create(
+        for contract in ContractLCM.objects.using(db).all():
+            ContactLCM.objects.using(db).create(
                 contract=contract,
                 name=f"Test Contact for {contract.name}",
             )
 
         # create CVELCM
         for i in range(1, 5):
-            cve = CVELCM.objects.create(
+            cve = CVELCM.objects.using(db).create(
                 name=f"Test CVELCM {i}",
                 published_date="2020-01-01",
                 link="http://cve.example.org/{i}/details/",
@@ -122,16 +117,13 @@ class Command(BaseCommand):
             cve.affected_softwares.set(get_random_instances(SoftwareLCM, minimum=1))
 
         # create VulnerabilityLCM
-        VulnerabilityLCM.objects.create(cve=CVELCM.objects.get(name="Test CVELCM 1"))
-        VulnerabilityLCM.objects.create(software=SoftwareLCM.objects.first())
-        VulnerabilityLCM.objects.create(device=Device.objects.first())
-        VulnerabilityLCM.objects.create(inventory_item=InventoryItem.objects.first())
+        VulnerabilityLCM.objects.using(db).create(cve=CVELCM.objects.using(db).get(name="Test CVELCM 1"))
+        VulnerabilityLCM.objects.using(db).create(software=SoftwareLCM.objects.using(db).first())
+        VulnerabilityLCM.objects.using(db).create(device=Device.objects.using(db).first())
+        VulnerabilityLCM.objects.using(db).create(inventory_item=InventoryItem.objects.using(db).first())
 
     def handle(self, *args, **options):
         """Entry point to the management command."""
-        # Call nautobot core's generate_test_data command to generate data for core models
-        call_command("generate_test_data", flush=options["flush"])
-
-        self._generate_static_data()
+        self._generate_static_data(db=options["database"])
 
         self.stdout.write(self.style.SUCCESS(f"Database {options['database']} populated with app data successfully!"))

--- a/nautobot_device_lifecycle_mgmt/software.py
+++ b/nautobot_device_lifecycle_mgmt/software.py
@@ -56,7 +56,7 @@ class ItemSoftware:
 
     def validate_software(self, preferred_only=False):
         """Validate software against the validated software objects."""
-        if not (self.software and self.validated_software_qs.count()):
+        if not (self.software and self.validated_software_qs.exists()):
             return False
 
         validated_software_versions = ValidatedSoftwareLCMFilterSet(
@@ -65,7 +65,7 @@ class ItemSoftware:
         if preferred_only:
             validated_software_versions = validated_software_versions.filter(preferred_only=True)
 
-        return validated_software_versions.count() > 0
+        return validated_software_versions.exists()
 
 
 class DeviceSoftware(ItemSoftware):

--- a/nautobot_device_lifecycle_mgmt/templates/nautobot_device_lifecycle_mgmt/inc/device_notice.html
+++ b/nautobot_device_lifecycle_mgmt/templates/nautobot_device_lifecycle_mgmt/inc/device_notice.html
@@ -1,108 +1,72 @@
 {% load helpers %}
 {% if perms.nautobot_device_lifecycle_mgmt.view_hardwarelcm and hw_notices %}
-<style type="text/css">
-    .panel-heading .accordion-toggle:after {
-        /* symbol for "opening" panels */
-        font-family: 'Glyphicons Halflings';  /* essential for enabling glyphicon */
-        content: "\e114";    /* adjust as needed, taken from bootstrap.css */
-        float: right;        /* adjust as needed */
-        color: grey;         /* adjust as needed */
-    }
-    .panel-heading .accordion-toggle.collapsed:after {
-        /* symbol for "collapsed" panels */
-        content: "\e080";    /* adjust as needed, taken from bootstrap.css */
-    }
-</style>
-
-<div class="row">
-    <div class="col-md-12">
-        <!-- Nav tabs to support both hardware and software notices. -->
-        <ul class="nav nav-tabs" role="tablist">
-            {% if hw_notices %}
-            <li role="presentation" class="active">
-                <a href="#hardware" aria-controls="hardware" role="tab" data-toggle="tab">
-                    Hardware Lifecycle Notices  <span class="badge badge-pill badge-primary">{{ hw_notices.count }}</span>
-                </a>
-
-            </li>
-            {% endif %}
-            {% if sw_notices %}
-            <li role="presentation"><a href="#software" aria-controls="software" role="tab" data-toggle="tab">Software Lifecycle Notices</a></li>
-            {% endif %}
-        </ul>
-
-        <div class="tab-content">
+            <style>
+                .accordion-toggle {
+                    font-size: 14px;
+                    font-weight: 700;
+                }
+            </style>
 
             <!-- Defines all hardware notice logic within this tab-panel. -->
-            <div role="tabpanel" class="tab-pane active" id="hardware">
-                <div class="panel-group" id="hwAccordion" role="tablist" aria-multiselectable="true">
-                    {% for notice in hw_notices %}
-                    {% if forloop.counter < 6 %}
-                    <div class="panel panel-{% if notice.expired %}danger{% else %}warning{% endif %}">
-                        <div class="panel-heading" role="tab" id="heading{{ forloop.counter }}">
-                            <span role="button"
-                                  class="accordion-toggle collapsed"
-                                  data-toggle="collapse"
-                                  data-parent="#hwAccordion"
-                                  href="#collapse{{ forloop.counter }}"
-                                  aria-expanded="false"
-                                  aria-controls="collapse{{ forloop.counter }}">
-                                {{ notice }}
-                            </span>
-                        </div>
-                        <div id="collapse{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{ forloop.counter }}">
-                            <div class="list-group">
-                                <table class="table">
-                                    <tr>
-                                        <td>End of Sale</td>
-                                        <td>{{ notice.end_of_sale }}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>End of Support</td>
-                                        <td>{{ notice.end_of_support }}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>End of Software Releases</td>
-                                        <td>{{ notice.end_of_sw_releases }}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>End of Security Patches</td>
-                                        <td>{{ notice.end_of_security_patches }}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Documentation URL</td>
-                                        <td>
-                                            {% if notice.documentation_url %}<a href="{{ notice.documentation_url }}">{{ notice.documentation_url }}</a>{% else %}&mdash;{% endif %}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>Comments</td>
-                                        <td>
-                                            {% if notice.comments %}<pre>{{ notice.comments }}</pre>{% else %}&mdash;{% endif %}
-                                        </td>
-                                    </tr>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
-                    {% elif forloop.counter == 6 %}
-                    <div class="panel-footer text-right noprint">
-                        <a href="{% url 'plugins:nautobot_device_lifecycle_mgmt:hardwarelcm_list'  %}?q={% for inv in object.inventoryitems.all %}&inventory_item={{ inv.part_id }}{% endfor %}" target="_blank" class="btn btn-primary btn-xs">
-                            <span class="mdi mdi-open-in-new" aria-hidden="true"></span>  See More Notices
-                        </a>
-                    </div>
-                    {% endif %}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>Hardware Lifecycle Notices {% badge hw_notices.count show_empty=True %}</strong>
+                </div>
+                <table id="accordion" class="table table-hover panel-body attr-table">
+                    {% for notice in hw_notices|slice:":5" %}
+                    <tbody>
+                        <tr>
+                            <th colspan="2">
+                                <button type="button" class="btn-link accordion-toggle mdi mdi-chevron-right"
+                                        name="hardware-notices-accordion-{{ forloop.counter }}" data-toggle="collapse"
+                                        data-target=".collapseme-hardware-notices-accordion-{{ forloop.counter }}">
+                                    {{ notice }}
+                                </button>
+                                {% if notice.expired %}
+                                    <span class="label label-danger pull-right">Expired</span>
+                                {% endif %}
+                            </th>
+                        </tr>
+                    </tbody>
+                    <tbody class="collapse collapseme-hardware-notices-accordion-{{ forloop.counter }}">
+                        <tr>
+                            <td>End of Sale</td>
+                            <td>{{ notice.end_of_sale|placeholder }}</td>
+                        </tr>
+                        <tr>
+                            <td>End of Support</td>
+                            <td>{{ notice.end_of_support|placeholder }}</td>
+                        </tr>
+                        <tr>
+                            <td>End of Software Releases</td>
+                            <td>{{ notice.end_of_sw_releases|placeholder }}</td>
+                        </tr>
+                        <tr>
+                            <td>End of Security Patches</td>
+                            <td>{{ notice.end_of_security_patches|placeholder }}</td>
+                        </tr>
+                        <tr>
+                            <td>Documentation URL</td>
+                            <td>
+                                {% if notice.documentation_url %}<a href="{{ notice.documentation_url }}">{{ notice.documentation_url }}</a>{% else %}{{ None|placeholder }}{% endif %}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Comments</td>
+                            <td>
+                                {% if notice.comments %}<pre>{{ notice.comments }}</pre>{% else %}{{ None|placeholder }}{% endif %}
+                            </td>
+                        </tr>
+                    </tbody>
                     {% endfor %}
+                </table>
+                {% if hw_notices|length > 5 %}
+                <div class="panel-footer text-right noprint">
+                    <a href="{% url 'plugins:nautobot_device_lifecycle_mgmt:hardwarelcm_list'  %}?q={% for inv in object.inventory_items.all %}{% if inv.part_id %}&inventory_item={{ inv.part_id|urlencode }}{% endif %}{% endfor %}" target="_blank" class="btn btn-primary btn-xs">
+                        <span class="mdi mdi-open-in-new" aria-hidden="true"></span>
+                        See More Notices
+                    </a>
                 </div>
+                {% endif %}
             </div>
-
-            <!-- Defines all software notice logic within this tab-panel. -->
-            <div role="tabpanel" class="tab-pane" id="software">
-                <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
 {% endif %}

--- a/nautobot_device_lifecycle_mgmt/templates/nautobot_device_lifecycle_mgmt/inc/general_notice.html
+++ b/nautobot_device_lifecycle_mgmt/templates/nautobot_device_lifecycle_mgmt/inc/general_notice.html
@@ -1,11 +1,10 @@
 {% load helpers %}
 {% if perms.nautobot_device_lifecycle_mgmt.view_hardwarelcm and hw_notices %}
 {% for notice in hw_notices %}
-<div class="row">
-    <div class="col-md-12">
-        <div class="panel {% if notice.expired %}panel-danger{% else %}panel-warning{% endif %}">
+        <div class="panel panel-default">
             <div class="panel-heading">
                 <strong>Hardware {% if notice.inventory_item %}Inventory Part {% endif %}Notice</strong>
+                {% if notice.expired %}<span class="label label-danger">Expired</span>{% endif %}
             </div>
             <table class="table table-hover panel-body attr-table">
                 <tr>
@@ -16,19 +15,19 @@
                 </tr>
                 <tr>
                     <td>End of Sale</td>
-                    <td>{{ notice.end_of_sale }}</td>
+                    <td>{{ notice.end_of_sale|placeholder }}</td>
                 </tr>
                 <tr>
                     <td>End of Support</td>
-                    <td>{{ notice.end_of_support }}</td>
+                    <td>{{ notice.end_of_support|placeholder }}</td>
                 </tr>
                 <tr>
                     <td>End of Software Releases</td>
-                    <td>{{ notice.end_of_sw_releases }}</td>
+                    <td>{{ notice.end_of_sw_releases|placeholder }}</td>
                 </tr>
                 <tr>
                     <td>End of Security Patches</td>
-                    <td>{{ notice.end_of_security_patches }}</td>
+                    <td>{{ notice.end_of_security_patches|placeholder }}</td>
                 </tr>
                 <tr>
                     <td>Documentation URL</td>
@@ -42,17 +41,9 @@
                 </tr>
                 <tr>
                     <td>Comments</td>
-                    <td>
-                        {% if notice.comments %}
-                        {{ notice.comments }}
-                        {% else %}
-                        &mdash;
-                        {% endif %}
-                    </td>
+                    <td>{{ notice.comments|placeholder }}</td>
                 </tr>
             </table>
         </div>
-    </div>
-</div>
 {% endfor %}
 {% endif %}

--- a/nautobot_device_lifecycle_mgmt/templates/nautobot_device_lifecycle_mgmt/inc/software_and_validatedsoftware_info.html
+++ b/nautobot_device_lifecycle_mgmt/templates/nautobot_device_lifecycle_mgmt/inc/software_and_validatedsoftware_info.html
@@ -1,16 +1,9 @@
 {% load helpers %}
 {% if perms.nautobot_device_lifecycle_mgmt.view_softwarelcm and perms.nautobot_device_lifecycle_mgmt.view_validatedsoftwarelcm %}
-<div class="row">
     {% if obj_soft %}
-    <div class="col-md-12">
         {% include 'nautobot_device_lifecycle_mgmt/inc/software_info.html' %}
-    </div>
     {% endif %}
     {% if validsoft_table %}
-    <div class="col-md-12">
         {% include 'nautobot_device_lifecycle_mgmt/inc/validatedsoftware_info.html' %}
-    </div>
     {% endif %}
-</div>
 {% endif %}
-

--- a/nautobot_device_lifecycle_mgmt/templates/nautobot_device_lifecycle_mgmt/inc/software_info.html
+++ b/nautobot_device_lifecycle_mgmt/templates/nautobot_device_lifecycle_mgmt/inc/software_info.html
@@ -1,12 +1,6 @@
-<div class="row">
-    <div class="col-md-12">
-        {% if obj_soft_valid %}
-        <div class="panel panel-success">
-        {% else %}
-        <div class="panel panel-danger">
-        {% endif %}
+        <div class="panel panel-default">
             <div class="panel-heading">
-                <strong>Software is {% if obj_soft_valid %}valid{% else %}invalid{% endif %}</strong>
+                <strong>Software</strong> {% if obj_soft_valid %}<span class="label label-success">Valid{% else %}<span class="label label-danger">Invalid{% endif %}</span>
             </div>
             <table class="table table-hover panel-body attr-table">
                 <tr>
@@ -29,5 +23,3 @@
                 </tr>
             </table>
         </div>
-    </div>
-</div>


### PR DESCRIPTION
## Closes #261 

This makes the changes to the template extensions as described in #261 but it also adds the `generate_dlm_test_data` management command, similar to the PR in golden config at https://github.com/nautobot/nautobot-app-golden-config/pull/809. This management command makes it easier to generate basic testing data in a development environment. If desired, I can move this to its own PR.

## Screenshots

### Device View

#### Before

![image](https://github.com/user-attachments/assets/6eb0f287-5dd4-44a2-bda4-80049d2c594c)

#### After

![image](https://github.com/user-attachments/assets/c3bbe19a-73e3-49f0-97dc-2c840296a8c5)

#### Before

![image](https://github.com/user-attachments/assets/a3c532e0-3550-4d63-8c7b-a6877bd36043)

#### After

![image](https://github.com/user-attachments/assets/5923ec91-80a6-4372-a3bf-f16195a63860)

#### Before

![image](https://github.com/user-attachments/assets/653b61cb-fa6c-42fe-a7eb-0a5c60f9f381)

#### After

![image](https://github.com/user-attachments/assets/9017e5f5-3e01-478a-8558-3d08de95f28c)

### DeviceType View

#### Before

![image](https://github.com/user-attachments/assets/129d9f31-8ae2-4ea0-b2bc-2620c8373685)

#### After

![image](https://github.com/user-attachments/assets/07f42e11-4713-40fb-b3bb-c3e3c2307afc)

#### Before

![image](https://github.com/user-attachments/assets/1f1bcb06-ee34-42d0-b8f7-a1f5e019996b)

#### After

![image](https://github.com/user-attachments/assets/846ece67-bed6-48a0-bbb1-7517bb57842a)
