### PR TITLE
## Fix issue #420

### DIFF
--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -597,13 +597,25 @@ class InventoryItemSoftwareValidationResultFilterForm(NautobotFilterForm):
 class ContractLCMForm(NautobotModelForm):
     """Device Lifecycle Contracts creation/edit form."""
 
+    def get_contract_types(choices) -> tuple[tuple[None|str]]:
+        """Get distinct contract types from ContractLCM."""
+        return (
+            (None, "---------"),
+            *tuple(choices),
+            *tuple((value, value) for value in list(
+                ContractLCM.objects.distinct('contract_type')
+                .values_list('contract_type', flat=True)
+                .order_by('contract_type')
+            ) if value not in {choice[0] for choice in choices}),
+        )
+
     provider = forms.ModelChoiceField(
         queryset=ProviderLCM.objects.all(),
         label="Vendor",
         to_field_name="pk",
         required=True,
     )
-    contract_type = forms.ChoiceField(choices=add_blank_choice(ContractTypeChoices.CHOICES), label="Contract Type")
+    contract_type = forms.ChoiceField(choices=get_contract_types(ContractTypeChoices.CHOICES), label="Contract Type")
     currency = forms.ChoiceField(required=False, choices=add_blank_choice(CurrencyChoices.CHOICES))
     tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
     devices = DynamicModelMultipleChoiceField(queryset=Device.objects.all(), required=False)


### PR DESCRIPTION
# Closes: #420

## What's Changed

Added get_contract_types function to ContractLCMForm class in order to merge existing custom contract_type values to the choices presented by the form "Contract Type" field.

Now existing custom contract_type values are shown in the dropdown list and is possible to save existing contracts and also add new contracts with existing contract_type.

![image](https://github.com/user-attachments/assets/878a6daa-2bc5-4497-8d11-f42b5aee8af5)
