### PR TITLE
Changes Devices on Contract view to count and link

### DIFF
--- a/changes/439.changed
+++ b/changes/439.changed
@@ -1,0 +1,1 @@
+Changed the Device list on an individual Contract's view to a count of devices with a link to the Device list filtered by the Contract.

--- a/nautobot_device_lifecycle_mgmt/filter_extensions.py
+++ b/nautobot_device_lifecycle_mgmt/filter_extensions.py
@@ -1,7 +1,10 @@
 """Extensions to core filters."""
 
 from django_filters import BooleanFilter
-from nautobot.apps.filters import FilterExtension
+from nautobot.apps.filters import FilterExtension, NaturalKeyOrPKMultipleChoiceFilter
+from nautobot.apps.forms import DynamicModelMultipleChoiceField
+
+from nautobot_device_lifecycle_mgmt.models import ContractLCM
 
 
 def distinct_filter(queryset, _, value):
@@ -23,4 +26,26 @@ class InventoryItemFilterExtension(FilterExtension):
     }
 
 
-filter_extensions = [InventoryItemFilterExtension]
+class DeviceFilterExtension(FilterExtension):
+    """Extends Device Filters."""
+
+    model = "dcim.device"
+
+    filterset_fields = {
+        "nautobot_device_lifecycle_mgmt_device_contracts": NaturalKeyOrPKMultipleChoiceFilter(
+            field_name="device_contracts",
+            queryset=ContractLCM.objects.all(),
+            label="Contracts",
+        )
+    }
+
+    filterform_fields = {
+        "nautobot_device_lifecycle_mgmt_device_contracts": DynamicModelMultipleChoiceField(
+            queryset=ContractLCM.objects.all(),
+            label="Contracts",
+            required=False,
+        )
+    }
+
+
+filter_extensions = [InventoryItemFilterExtension, DeviceFilterExtension]

--- a/nautobot_device_lifecycle_mgmt/templates/nautobot_device_lifecycle_mgmt/contractlcm_retrieve.html
+++ b/nautobot_device_lifecycle_mgmt/templates/nautobot_device_lifecycle_mgmt/contractlcm_retrieve.html
@@ -55,9 +55,7 @@
             <tr>
                 <td>Devices</td>
                 <td>
-                    {% for device in object.devices.all %}
-                    <a href="{% url 'dcim:device' pk=device.pk %}">{{ device }}</a>{% if not forloop.last %}, {% endif %}
-                    {% endfor %}
+                    <a href="{% url 'dcim:device_list'  %}?nautobot_device_lifecycle_mgmt_device_contracts={{ object.id }}">{{ object.devices.count }}</a>
                 </td>
             </tr>
             <tr>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Lifecycle Management! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #439

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

<details>
    <summary>Before</summary>

Currently, the detailed view showed a list of all devices associated to it. This can cause issues at scale as it has to load all of those devices before the page can load.

![Screenshot 2025-04-01 at 11 52 48 AM](https://github.com/user-attachments/assets/5014651e-8de9-4634-be20-41d1e74b85d9)

</details>

<details>
    <summary>After</summary>

With this change, the device list has changed to a count and the count is a hyperlink to the Device list with a filter pre-applied.

![Screenshot 2025-04-01 at 11 52 04 AM](https://github.com/user-attachments/assets/8787616a-fe7c-4095-8b5f-21b32971c96a)
![Screenshot 2025-04-01 at 11 52 13 AM](https://github.com/user-attachments/assets/83f22ec2-826b-4f49-beff-b60981d1e820)

</details>

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
