### PR TITLE
Nist url logging bugfix

### DIFF
--- a/changes/462.fixed
+++ b/changes/462.fixed
@@ -1,0 +1,1 @@
+Added TypeError exception to provide logging on what version needs attention.  Job continues.

--- a/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py
+++ b/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py
@@ -182,6 +182,17 @@ class NistCveSyncSoftware(Job):
                 )
                 continue
 
+            except TypeError as err:
+                self.logger.error(
+                    "There was an error in creating URLs for this Software Version. Please check the version value for %s %s %s. ERROR: %s",
+                    software.platform.manufacturer.name,
+                    software.platform.network_driver,
+                    software.version,
+                    err,
+                    extra={"grouping": "URL Creation"},
+                )
+                continue
+            
             self.logger.info(
                 "Gathering CVE Information for Software Version: %s",
                 version,

--- a/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py
+++ b/nautobot_device_lifecycle_mgmt/jobs/cve_tracking.py
@@ -192,7 +192,7 @@ class NistCveSyncSoftware(Job):
                     extra={"grouping": "URL Creation"},
                 )
                 continue
-            
+
             self.logger.info(
                 "Gathering CVE Information for Software Version: %s",
                 version,


### PR DESCRIPTION
## What's Changed

Recent merge to develop for NIST Automated CVE Tracking job had a bug discovered before release that was causing job to fail without proper logging on why.

Added a TypeError exception to catch this, provide log message, and continue.

![Screenshot 2025-05-23 at 10 56 22 AM](https://github.com/user-attachments/assets/4af02c1a-ebea-44bb-86ac-00565f5995e8)

