### PR TITLE
Fix tags on multiple models, form saves, and object lists

### DIFF
--- a/changes/609.added
+++ b/changes/609.added
@@ -1,0 +1,1 @@
+Added tag support to the bulk edit forms for Hardware Notice, Validated Software, Contract, CVE, and Vulnerability objects. Tags are now applied through the `Add tags` and `Remove tags` fields honored by Nautobot's bulk edit view; the previous `Tags` field on the CVE and Vulnerability bulk edit forms had no effect.

--- a/changes/609.fixed
+++ b/changes/609.fixed
@@ -1,0 +1,3 @@
+Fixed tags being silently discarded when creating or editing Validated Software, CVE, and Vulnerability objects in the UI. Their forms declared a `tags` field but omitted `"tags"` from an explicit `Meta.fields`, so Django's `_save_m2m()` never persisted the selection.
+
+Fixed `AttributeError` when bulk editing Contract objects. `StatusModelBulkEditFormMixin` was listed after `NautobotBulkEditForm` on `ContractLCMBulkEditForm`, which placed it after `BulkEditForm` in the MRO and ran its `__init__()` before `self.model` was assigned.

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -20,6 +20,7 @@ from nautobot.apps.forms import (
     StatusModelBulkEditFormMixin,
     StatusModelFilterFormMixin,
     TagFilterField,
+    TagsBulkEditFormMixin,
     add_blank_choice,
 )
 from nautobot.core.forms.constants import BOOLEAN_WITH_BLANK_CHOICES
@@ -104,7 +105,7 @@ class HardwareLCMForm(NautobotModelForm):
         }
 
 
-class HardwareLCMBulkEditForm(NautobotBulkEditForm):
+class HardwareLCMBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm):
     """Hardware Device Lifecycle bulk edit form."""
 
     pk = forms.ModelMultipleChoiceField(queryset=HardwareLCM.objects.all(), widget=forms.MultipleHiddenInput)
@@ -185,8 +186,6 @@ class ValidatedSoftwareLCMForm(NautobotModelForm):
     inventory_items = DynamicModelMultipleChoiceField(queryset=InventoryItem.objects.all(), required=False)
     object_tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
 
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
-
     class Meta:
         """Meta attributes."""
 
@@ -204,6 +203,7 @@ class ValidatedSoftwareLCMForm(NautobotModelForm):
             "start",
             "end",
             "preferred",
+            "tags",
         ]
 
         widgets = {
@@ -230,7 +230,7 @@ class ValidatedSoftwareLCMForm(NautobotModelForm):
             self.add_error(None, "You need to assign to at least one object.")
 
 
-class ValidatedSoftwareLCMBulkEditForm(NautobotBulkEditForm):
+class ValidatedSoftwareLCMBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm):
     """Validated Software Lifecycle bulk edit form."""
 
     model = ValidatedSoftwareLCM
@@ -637,7 +637,6 @@ class ContractLCMForm(NautobotModelForm):
     )
     contract_type = forms.ChoiceField(choices=add_blank_choice(ContractTypeChoices.CHOICES), label="Contract Type")
     currency = forms.ChoiceField(required=False, choices=add_blank_choice(CurrencyChoices.CHOICES))
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
     devices = DynamicModelMultipleChoiceField(queryset=Device.objects.all(), required=False)
 
     class Meta:
@@ -656,7 +655,7 @@ class ContractLCMForm(NautobotModelForm):
         return {"provider": self.request.GET.get("provider")}  # pylint: disable=E1101
 
 
-class ContractLCMBulkEditForm(NautobotBulkEditForm, StatusModelBulkEditFormMixin):
+class ContractLCMBulkEditForm(TagsBulkEditFormMixin, StatusModelBulkEditFormMixin, NautobotBulkEditForm):
     """Device Lifecycle Contrcts bulk edit form."""
 
     pk = forms.ModelMultipleChoiceField(queryset=ContractLCM.objects.all(), widget=forms.MultipleHiddenInput)
@@ -800,7 +799,6 @@ class CVELCMForm(NautobotModelForm):
     published_date = forms.DateField(widget=DatePicker())
     last_modified_date = forms.DateField(widget=DatePicker(), required=False)
     severity = forms.ChoiceField(choices=CVESeverityChoices.CHOICES, label="Severity", required=False)
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
     affected_softwares = DynamicModelMultipleChoiceField(queryset=SoftwareVersion.objects.all(), required=False)
     comments = CommentField(label="Comments", required=False)
 
@@ -825,6 +823,7 @@ class CVELCMForm(NautobotModelForm):
             "fix",
             "comments",
             "affected_softwares",
+            "tags",
         ]
 
         widgets = {
@@ -833,14 +832,13 @@ class CVELCMForm(NautobotModelForm):
         }
 
 
-class CVELCMBulkEditForm(NautobotBulkEditForm, CustomFieldModelBulkEditFormMixin):
+class CVELCMBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm, CustomFieldModelBulkEditFormMixin):
     """CVE Lifecycle Management bulk edit form."""
 
     model = CVELCM
     pk = forms.ModelMultipleChoiceField(queryset=CVELCM.objects.all(), widget=forms.MultipleHiddenInput)
     description = forms.CharField(required=False, widget=forms.Textarea)
     comments = CommentField(required=False)
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
     status = DynamicModelChoiceField(
         queryset=Status.objects.all(),
         required=False,
@@ -854,7 +852,6 @@ class CVELCMBulkEditForm(NautobotBulkEditForm, CustomFieldModelBulkEditFormMixin
             "description",
             "comments",
             "status",
-            "tags",
         ]
 
 
@@ -922,8 +919,6 @@ class CVELCMFilterForm(NautobotFilterForm):
 class VulnerabilityLCMForm(NautobotModelForm):
     """Vulnerability Lifecycle Management creation/edit form."""
 
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
-
     class Meta:
         """Meta attributes for the VulnerabilityLCMForm class."""
 
@@ -937,14 +932,14 @@ class VulnerabilityLCMForm(NautobotModelForm):
             "device",
             "inventory_item",
             "status",
+            "tags",
         ]
 
 
-class VulnerabilityLCMBulkEditForm(NautobotBulkEditForm, CustomFieldModelBulkEditFormMixin):
+class VulnerabilityLCMBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm, CustomFieldModelBulkEditFormMixin):
     """Vulnerability Lifecycle Management bulk edit form."""
 
     pk = forms.ModelMultipleChoiceField(queryset=VulnerabilityLCM.objects.all(), widget=forms.MultipleHiddenInput)
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
 
     class Meta:
         """Meta attributes for the VulnerabilityLCMBulkEditForm class."""
@@ -952,7 +947,6 @@ class VulnerabilityLCMBulkEditForm(NautobotBulkEditForm, CustomFieldModelBulkEdi
         model = VulnerabilityLCM
         nullable_fields = [
             "status",
-            "tags",
         ]
 
 

--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -66,12 +66,26 @@ class HardwareLCMTable(BaseTable):
         verbose_name="Documentation",
     )
     actions = ButtonsColumn(HardwareLCM, buttons=("changelog", "edit", "delete"))
+    tags = TagColumn(url_name="plugins:nautobot_device_lifecycle_mgmt:hardwarelcm_list")
 
     class Meta(BaseTable.Meta):
         """Meta attributes."""
 
         model = HardwareLCM
         fields = (
+            "pk",
+            "name",
+            "reference_item",
+            "release_date",
+            "end_of_sale",
+            "end_of_support",
+            "end_of_sw_releases",
+            "end_of_security_patches",
+            "documentation_url",
+            "tags",
+            "actions",
+        )
+        default_columns = (
             "pk",
             "name",
             "reference_item",
@@ -102,12 +116,25 @@ class ValidatedSoftwareLCMTable(BaseTable):
     device_tenants = tables.ManyToManyColumn(verbose_name="Tenant")
     actions = ButtonsColumn(ValidatedSoftwareLCM, buttons=("edit", "delete"))
     preferred = BooleanColumn()
+    tags = TagColumn(url_name="plugins:nautobot_device_lifecycle_mgmt:validatedsoftwarelcm_list")
 
     class Meta(BaseTable.Meta):
         """Meta attributes."""
 
         model = ValidatedSoftwareLCM
         fields = (
+            "pk",
+            "name",
+            "software",
+            "device_tenants",
+            "start",
+            "end",
+            "valid",
+            "preferred",
+            "tags",
+            "actions",
+        )
+        default_columns = (
             "pk",
             "name",
             "software",
@@ -441,7 +468,6 @@ class ContractLCMTable(StatusTableMixin, BaseTable):
             "contract_type",
             "provider",
             "active",
-            "tags",
             "actions",
         )
 
@@ -495,7 +521,7 @@ class CVELCMTable(StatusTableMixin, BaseTable):
                     {% endif %}""",
         verbose_name="Link",
     )
-    tags = TagColumn()
+    tags = TagColumn(url_name="plugins:nautobot_device_lifecycle_mgmt:cvelcm_list")
     actions = ButtonsColumn(CVELCM, buttons=("changelog", "edit", "delete"))
 
     class Meta(BaseTable.Meta):
@@ -544,7 +570,7 @@ class VulnerabilityLCMTable(StatusTableMixin, BaseTable):
     software = tables.LinkColumn()
     device = tables.LinkColumn()
     inventory_item = tables.LinkColumn(verbose_name="Inventory Item")
-    tags = TagColumn()
+    tags = TagColumn(url_name="plugins:nautobot_device_lifecycle_mgmt:vulnerabilitylcm_list")
     actions = ButtonsColumn(VulnerabilityLCM, buttons=("changelog", "edit", "delete"))
 
     class Meta(BaseTable.Meta):

--- a/nautobot_device_lifecycle_mgmt/tests/test_forms.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_forms.py
@@ -238,7 +238,11 @@ class ValidatedSoftwareLCMFormTest(TestCase):  # pylint: disable=no-member
         self.assertTrue(form.save())
 
     def test_tags_are_saved(self):
-        """Tags selected on the form must be persisted, not silently dropped."""
+        """Tags selected on the form must be persisted, not silently dropped.
+
+        ValidatedSoftwareLCM has no PrimaryObjectViewTestCase, so the generic create/edit tests that
+        assert tag persistence via `form_data` do not cover it.
+        """
         tag = Tag.objects.create(name="Validated Software Tag")
         tag.content_types.add(ContentType.objects.get_for_model(ValidatedSoftwareLCM))
         data = {
@@ -397,23 +401,6 @@ class CVELCMFormTest(TestCase):
         )
         self.assertTrue(form.is_valid())
         self.assertTrue(form.save())
-
-    def test_tags_are_saved(self):
-        """Tags selected on the form must be persisted, not silently dropped."""
-        tag = Tag.objects.create(name="CVE Tag")
-        tag.content_types.add(self.cve_ct)
-        form = CVELCMForm(
-            data={
-                "name": "CVE-2021-34700",
-                "published_date": "2021-09-23",
-                "link": "https://www.cvedetails.com/cve/CVE-2021-34700/",
-                "status": self.status,
-                "tags": [tag.pk],
-            }
-        )
-        self.assertTrue(form.is_valid(), form.errors)
-        cve = form.save()
-        self.assertEqual(list(cve.tags.values_list("name", flat=True)), ["CVE Tag"])
 
     def test_required_fields_missing(self):
         form = CVELCMForm(data={"name": "CVE-2022-0002"})

--- a/nautobot_device_lifecycle_mgmt/tests/test_forms.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_forms.py
@@ -14,17 +14,29 @@ from nautobot.dcim.models import (
     Platform,
     SoftwareVersion,
 )
-from nautobot.extras.models import Role, Status
+from nautobot.extras.models import Role, Status, Tag
 from nautobot.tenancy.models import Tenant
 
 from nautobot_device_lifecycle_mgmt.forms import (
+    ContractLCMBulkEditForm,
     ContractLCMForm,
+    CVELCMBulkEditForm,
     CVELCMForm,
+    HardwareLCMBulkEditForm,
     HardwareLCMForm,
     ProviderLCM,
+    ValidatedSoftwareLCMBulkEditForm,
     ValidatedSoftwareLCMForm,
+    VulnerabilityLCMBulkEditForm,
+    VulnerabilityLCMForm,
 )
-from nautobot_device_lifecycle_mgmt.models import CVELCM, ContractLCM
+from nautobot_device_lifecycle_mgmt.models import (
+    CVELCM,
+    ContractLCM,
+    HardwareLCM,
+    ValidatedSoftwareLCM,
+    VulnerabilityLCM,
+)
 
 
 class HardwareLCMFormTest(TestCase):
@@ -225,6 +237,23 @@ class ValidatedSoftwareLCMFormTest(TestCase):  # pylint: disable=no-member
         self.assertTrue(form.is_valid())
         self.assertTrue(form.save())
 
+    def test_tags_are_saved(self):
+        """Tags selected on the form must be persisted, not silently dropped."""
+        tag = Tag.objects.create(name="Validated Software Tag")
+        tag.content_types.add(ContentType.objects.get_for_model(ValidatedSoftwareLCM))
+        data = {
+            "software": self.software,
+            "devices": [self.device_1],
+            "start": "2021-06-06",
+            "end": "2023-08-31",
+            "preferred": False,
+            "tags": [tag.pk],
+        }
+        form = self.form_class(data)
+        self.assertTrue(form.is_valid(), form.errors)
+        validated_software = form.save()
+        self.assertEqual(list(validated_software.tags.values_list("name", flat=True)), ["Validated Software Tag"])
+
     def test_specifying_all_fields_w_device_type(self):
         data = {
             "software": self.software,
@@ -369,6 +398,23 @@ class CVELCMFormTest(TestCase):
         self.assertTrue(form.is_valid())
         self.assertTrue(form.save())
 
+    def test_tags_are_saved(self):
+        """Tags selected on the form must be persisted, not silently dropped."""
+        tag = Tag.objects.create(name="CVE Tag")
+        tag.content_types.add(self.cve_ct)
+        form = CVELCMForm(
+            data={
+                "name": "CVE-2021-34700",
+                "published_date": "2021-09-23",
+                "link": "https://www.cvedetails.com/cve/CVE-2021-34700/",
+                "status": self.status,
+                "tags": [tag.pk],
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        cve = form.save()
+        self.assertEqual(list(cve.tags.values_list("name", flat=True)), ["CVE Tag"])
+
     def test_required_fields_missing(self):
         form = CVELCMForm(data={"name": "CVE-2022-0002"})
         self.assertFalse(form.is_valid())
@@ -463,3 +509,58 @@ class ContractLCMFormTest(TestCase):
             },
             form.errors,
         )
+
+
+class TaggableModelFormTest(TestCase):
+    """Test tag support on the create/edit forms of taggable Lifecycle Management models."""
+
+    form_classes = (
+        HardwareLCMForm,
+        ValidatedSoftwareLCMForm,
+        ContractLCMForm,
+        CVELCMForm,
+        VulnerabilityLCMForm,
+    )
+
+    def test_tags_field_present(self):
+        """The tags widget must be offered by the form."""
+        for form_class in self.form_classes:
+            with self.subTest(form=form_class.__name__):
+                self.assertIn("tags", form_class().fields)
+
+    def test_tags_included_in_meta_fields(self):
+        """Django's _save_m2m() drops tags unless "tags" is listed in an explicit Meta.fields."""
+        for form_class in self.form_classes:
+            with self.subTest(form=form_class.__name__):
+                meta_fields = form_class._meta.fields  # pylint: disable=protected-access, no-member
+                # ModelFormMetaclass normalizes `fields = "__all__"` to None, which saves every model field.
+                if meta_fields is not None:
+                    self.assertIn("tags", meta_fields)
+
+
+class TaggableModelBulkEditFormTest(TestCase):
+    """Test tag support on the bulk edit forms of taggable Lifecycle Management models."""
+
+    forms_and_models = (
+        (HardwareLCMBulkEditForm, HardwareLCM),
+        (ValidatedSoftwareLCMBulkEditForm, ValidatedSoftwareLCM),
+        (ContractLCMBulkEditForm, ContractLCM),
+        (CVELCMBulkEditForm, CVELCM),
+        (VulnerabilityLCMBulkEditForm, VulnerabilityLCM),
+    )
+
+    def test_add_and_remove_tags_fields_present(self):
+        """The bulk edit view only applies tags through the `add_tags` and `remove_tags` fields."""
+        for form_class, model in self.forms_and_models:
+            with self.subTest(form=form_class.__name__):
+                form = form_class(model)
+                self.assertIn("add_tags", form.fields)
+                self.assertIn("remove_tags", form.fields)
+
+    def test_tags_is_not_a_bulk_edit_field(self):
+        """A plain `tags` field is silently ignored by the bulk edit view, so it must not be offered."""
+        for form_class, model in self.forms_and_models:
+            with self.subTest(form=form_class.__name__):
+                form = form_class(model)
+                self.assertNotIn("tags", form.fields)
+                self.assertNotIn("tags", form.nullable_fields)

--- a/nautobot_device_lifecycle_mgmt/tests/test_tables.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_tables.py
@@ -1,0 +1,49 @@
+"""Test tables."""
+
+from django.test import TestCase
+from django.urls import reverse
+
+from nautobot_device_lifecycle_mgmt.tables import (
+    ContractLCMTable,
+    CVELCMTable,
+    HardwareLCMTable,
+    ValidatedSoftwareLCMTable,
+    VulnerabilityLCMTable,
+)
+
+
+# `base_columns` is added to each table by the django-tables2 metaclass, so pylint cannot see it.
+class TaggableModelTableTest(TestCase):
+    """Test the tags column on the list view tables of taggable Lifecycle Management models."""
+
+    table_classes = (
+        HardwareLCMTable,
+        ValidatedSoftwareLCMTable,
+        ContractLCMTable,
+        CVELCMTable,
+        VulnerabilityLCMTable,
+    )
+
+    def test_tags_column_is_available(self):
+        """The tags column must be selectable in the table configuration."""
+        for table_class in self.table_classes:
+            with self.subTest(table=table_class.__name__):
+                self.assertIn("tags", table_class.base_columns)  # pylint: disable=no-member
+
+    def test_tags_column_is_not_a_default_column(self):
+        """The tags column must be hidden until a user opts into it."""
+        for table_class in self.table_classes:
+            with self.subTest(table=table_class.__name__):
+                default_columns = getattr(table_class.Meta, "default_columns", [])
+                # Without default_columns nothing is hidden, so every column in `fields` shows by default.
+                self.assertTrue(default_columns, "default_columns must be set for tags to be hidden by default")
+                self.assertNotIn("tags", default_columns)
+
+    def test_tags_column_links_to_filtered_list_view(self):
+        """Tag badges link to the list view filtered by tag, so the column needs a reversible url_name."""
+        for table_class in self.table_classes:
+            with self.subTest(table=table_class.__name__):
+                tags_column = table_class.base_columns["tags"]  # pylint: disable=no-member
+                url_name = tags_column.extra_context.get("url_name")
+                self.assertIsNotNone(url_name)
+                self.assertTrue(reverse(url_name))

--- a/nautobot_device_lifecycle_mgmt/tests/test_views.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_views.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from nautobot.apps.testing import ViewTestCases
 from nautobot.dcim.models import DeviceType, Manufacturer
-from nautobot.extras.models import Status
+from nautobot.extras.models import Status, Tag
 from nautobot.users.models import ObjectPermission
 
 from nautobot_device_lifecycle_mgmt.models import (
@@ -50,10 +50,15 @@ class HardwareLCMViewTest(ViewTestCases.PrimaryObjectViewTestCase):
         HardwareLCM.objects.create(device_type=device_types[1], end_of_sale=datetime.date(2021, 4, 1))
         HardwareLCM.objects.create(device_type=device_types[2], end_of_sale=datetime.date(2021, 4, 1))
 
+        # Including tags in form_data makes the generic create/edit tests assert that they are persisted.
+        tag = Tag.objects.create(name="Hardware Notice Tag")
+        tag.content_types.add(ContentType.objects.get_for_model(HardwareLCM))
+
         cls.form_data = {
             "device_type": device_types[3].id,
             "end_of_sale": datetime.date(2021, 4, 1),
             "end_of_support": datetime.date(2024, 4, 1),
+            "tags": [tag.pk],
         }
         cls.csv_data = (
             "device_type,end_of_sale,end_of_support,end_of_sw_releases,end_of_security_patches,documentation_url",
@@ -239,10 +244,15 @@ class CVELCMViewTest(ViewTestCases.PrimaryObjectViewTestCase):
             "status": Status.objects.get_for_model(CVELCM).first().pk,
         }
 
+        # Including tags in form_data makes the generic create/edit tests assert that they are persisted.
+        tag = Tag.objects.create(name="CVE Tag")
+        tag.content_types.add(ContentType.objects.get_for_model(CVELCM))
+
         cls.form_data = {
             "name": "Test 1",
             "published_date": datetime.date(2022, 1, 1),
             "link": "https://www.cvedetails.com/cve/CVE-2022-0001/",
+            "tags": [tag.pk],
         }
 
     @skip("Not implemented")


### PR DESCRIPTION
Closes: #534 #609

This pull request adds robust tag support across the Hardware Notice, Validated Software, Contract, CVE, and Vulnerability models, ensuring that tags are properly handled in both the UI forms and bulk edit views. It addresses previous issues where tags were not saved or were silently ignored, and improves the tables and tests to reflect and verify this functionality.

**Tagging Support and Bug Fixes:**

* Fixed an issue where tags were silently discarded when creating or editing Validated Software, CVE, and Vulnerability objects due to missing `"tags"` in `Meta.fields`.
* Corrected the method resolution order for `ContractLCMBulkEditForm` to fix an `AttributeError` during bulk edits.

**Bulk Edit and Form Improvements:**

* Added `TagsBulkEditFormMixin` to the bulk edit forms for Hardware Notice, Validated Software, Contract, CVE, and Vulnerability models, ensuring that tags can be added or removed via the bulk edit interface. The old, non-functional `tags` field was removed from these forms. [[1]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3L107-R108) [[2]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3L233-R233) [[3]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3L659-R658) [[4]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3L836-L843) [[5]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3R935-L955)
* Updated the single-object forms to include `"tags"` in their `Meta.fields`, ensuring tags are saved as expected. [[1]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3R206) [[2]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3R826) Fd7b9f35L932R932)

**Tables and UI:**

* Added a `tags` column (with appropriate URL filtering) to the list view tables for all taggable models, and ensured the column is hidden by default until selected by the user. [[1]](diffhunk://#diff-352078346e05a539873d619415c61d91611d05bef042d45a35f0a4be84407610R69-R88) [[2]](diffhunk://#diff-352078346e05a539873d619415c61d91611d05bef042d45a35f0a4be84407610R119-R137) [[3]](diffhunk://#diff-352078346e05a539873d619415c61d91611d05bef042d45a35f0a4be84407610L498-R524) [[4]](diffhunk://#diff-352078346e05a539873d619415c61d91611d05bef042d45a35f0a4be84407610L547-R573) [[5]](diffhunk://#diff-bf95f2e1497740d75a022651324c46fce019f3ab8c05116c166b6b9b424bf954R1-R49)

**Testing:**

* Added and enhanced tests to verify that tags are correctly present in forms, properly saved, and that the bulk edit and table behaviors are as expected. [[1]](diffhunk://#diff-82c83d58542d2a4e205533a2b4b668e200d7565d0f424dc46b78febecb0d66f6R240-R256) [[2]](diffhunk://#diff-82c83d58542d2a4e205533a2b4b668e200d7565d0f424dc46b78febecb0d66f6R401-R417) [[3]](diffhunk://#diff-82c83d58542d2a4e205533a2b4b668e200d7565d0f424dc46b78febecb0d66f6R512-R566) [[4]](diffhunk://#diff-bf95f2e1497740d75a022651324c46fce019f3ab8c05116c166b6b9b424bf954R1-R49)

**Documentation:**

* Updated the change log to document the addition of tag support to bulk edit forms and clarify the previous limitations.