### PR TITLE
Fix tags on various models and views

### DIFF
--- a/changes/609.added
+++ b/changes/609.added
@@ -1,0 +1,3 @@
+Added tag support to the bulk edit forms for Hardware Notice, Validated Software, Contract, CVE, and Vulnerability objects. Tags are now applied through the `Add tags` and `Remove tags` fields honored by Nautobot's bulk edit view; the previous `Tags` field on the CVE and Vulnerability bulk edit forms had no effect.
+
+Added a selectable (non-default) tags column to the Hardware Notice and Validated Software list views.

--- a/changes/609.fixed
+++ b/changes/609.fixed
@@ -1,0 +1,3 @@
+Fixed tags being silently discarded when creating or editing Validated Software, CVE, and Vulnerability objects in the UI. Their forms declared a `tags` field but omitted `"tags"` from an explicit `Meta.fields`, so Django's `_save_m2m()` never persisted the selection.
+
+Fixed the Contract list view showing the tags column by default. Tags are now available but hidden, matching the other Lifecycle Management list views.

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -17,6 +17,7 @@ from nautobot.apps.forms import (
     StaticSelect2,
     StaticSelect2Multiple,
     TagFilterField,
+    TagsBulkEditFormMixin,
     add_blank_choice,
 )
 from nautobot.core.forms.constants import BOOLEAN_WITH_BLANK_CHOICES
@@ -96,7 +97,7 @@ class HardwareLCMForm(NautobotModelForm):
         }
 
 
-class HardwareLCMBulkEditForm(NautobotBulkEditForm):
+class HardwareLCMBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm):
     """Hardware Device Lifecycle bulk edit form."""
 
     pk = forms.ModelMultipleChoiceField(queryset=HardwareLCM.objects.all(), widget=forms.MultipleHiddenInput)
@@ -176,8 +177,6 @@ class ValidatedSoftwareLCMForm(NautobotModelForm):
     inventory_items = DynamicModelMultipleChoiceField(queryset=InventoryItem.objects.all(), required=False)
     object_tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
 
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
-
     class Meta:
         """Meta attributes."""
 
@@ -194,6 +193,7 @@ class ValidatedSoftwareLCMForm(NautobotModelForm):
             "start",
             "end",
             "preferred",
+            "tags",
         ]
 
         widgets = {
@@ -216,7 +216,7 @@ class ValidatedSoftwareLCMForm(NautobotModelForm):
             self.add_error(None, msg)
 
 
-class ValidatedSoftwareLCMBulkEditForm(NautobotBulkEditForm):
+class ValidatedSoftwareLCMBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm):
     """Validated Software Lifecycle bulk edit form."""
 
     model = ValidatedSoftwareLCM
@@ -591,7 +591,6 @@ class ContractLCMForm(NautobotModelForm):
     )
     contract_type = forms.ChoiceField(choices=add_blank_choice(ContractTypeChoices.CHOICES), label="Contract Type")
     currency = forms.ChoiceField(required=False, choices=add_blank_choice(CurrencyChoices.CHOICES))
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
     devices = DynamicModelMultipleChoiceField(queryset=Device.objects.all(), required=False)
 
     class Meta:
@@ -610,7 +609,7 @@ class ContractLCMForm(NautobotModelForm):
         return {"provider": self.request.GET.get("provider")}  # pylint: disable=E1101
 
 
-class ContractLCMBulkEditForm(NautobotBulkEditForm):
+class ContractLCMBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm):
     """Device Lifecycle Contrcts bulk edit form."""
 
     pk = forms.ModelMultipleChoiceField(queryset=ContractLCM.objects.all(), widget=forms.MultipleHiddenInput)
@@ -754,7 +753,6 @@ class CVELCMForm(NautobotModelForm):
     published_date = forms.DateField(widget=DatePicker())
     last_modified_date = forms.DateField(widget=DatePicker(), required=False)
     severity = forms.ChoiceField(choices=CVESeverityChoices.CHOICES, label="Severity", required=False)
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
     affected_softwares = DynamicModelMultipleChoiceField(queryset=SoftwareVersion.objects.all(), required=False)
     comments = CommentField(label="Comments", required=False)
 
@@ -779,6 +777,7 @@ class CVELCMForm(NautobotModelForm):
             "fix",
             "comments",
             "affected_softwares",
+            "tags",
         ]
 
         widgets = {
@@ -787,14 +786,13 @@ class CVELCMForm(NautobotModelForm):
         }
 
 
-class CVELCMBulkEditForm(NautobotBulkEditForm, CustomFieldModelBulkEditFormMixin):
+class CVELCMBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm, CustomFieldModelBulkEditFormMixin):
     """CVE Lifecycle Management bulk edit form."""
 
     model = CVELCM
     pk = forms.ModelMultipleChoiceField(queryset=CVELCM.objects.all(), widget=forms.MultipleHiddenInput)
     description = forms.CharField(required=False, widget=forms.Textarea)
     comments = CommentField(required=False)
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
     status = DynamicModelChoiceField(
         queryset=Status.objects.all(), required=False, query_params={"content_types": model._meta.label_lower}
     )
@@ -806,7 +804,6 @@ class CVELCMBulkEditForm(NautobotBulkEditForm, CustomFieldModelBulkEditFormMixin
             "description",
             "comments",
             "status",
-            "tags",
         ]
 
 
@@ -874,8 +871,6 @@ class CVELCMFilterForm(NautobotFilterForm):
 class VulnerabilityLCMForm(NautobotModelForm):
     """Vulnerability Lifecycle Management creation/edit form."""
 
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
-
     class Meta:
         """Meta attributes for the VulnerabilityLCMForm class."""
 
@@ -889,14 +884,14 @@ class VulnerabilityLCMForm(NautobotModelForm):
             "device",
             "inventory_item",
             "status",
+            "tags",
         ]
 
 
-class VulnerabilityLCMBulkEditForm(NautobotBulkEditForm, CustomFieldModelBulkEditFormMixin):
+class VulnerabilityLCMBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm, CustomFieldModelBulkEditFormMixin):
     """Vulnerability Lifecycle Management bulk edit form."""
 
     pk = forms.ModelMultipleChoiceField(queryset=VulnerabilityLCM.objects.all(), widget=forms.MultipleHiddenInput)
-    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
 
     class Meta:
         """Meta attributes for the VulnerabilityLCMBulkEditForm class."""
@@ -904,7 +899,6 @@ class VulnerabilityLCMBulkEditForm(NautobotBulkEditForm, CustomFieldModelBulkEdi
         model = VulnerabilityLCM
         nullable_fields = [
             "status",
-            "tags",
         ]
 
 

--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -56,12 +56,26 @@ class HardwareLCMTable(BaseTable):
         verbose_name="Documentation",
     )
     actions = ButtonsColumn(HardwareLCM, buttons=("changelog", "edit", "delete"))
+    tags = TagColumn(url_name="plugins:nautobot_device_lifecycle_mgmt:hardwarelcm_list")
 
     class Meta(BaseTable.Meta):
         """Meta attributes."""
 
         model = HardwareLCM
         fields = (
+            "pk",
+            "name",
+            "reference_item",
+            "release_date",
+            "end_of_sale",
+            "end_of_support",
+            "end_of_sw_releases",
+            "end_of_security_patches",
+            "documentation_url",
+            "tags",
+            "actions",
+        )
+        default_columns = (
             "pk",
             "name",
             "reference_item",
@@ -91,12 +105,24 @@ class ValidatedSoftwareLCMTable(BaseTable):
     software = tables.LinkColumn(verbose_name="Software")
     actions = ButtonsColumn(ValidatedSoftwareLCM, buttons=("edit", "delete"))
     preferred = BooleanColumn()
+    tags = TagColumn(url_name="plugins:nautobot_device_lifecycle_mgmt:validatedsoftwarelcm_list")
 
     class Meta(BaseTable.Meta):
         """Meta attributes."""
 
         model = ValidatedSoftwareLCM
         fields = (
+            "pk",
+            "name",
+            "software",
+            "start",
+            "end",
+            "valid",
+            "preferred",
+            "tags",
+            "actions",
+        )
+        default_columns = (
             "pk",
             "name",
             "software",
@@ -427,7 +453,6 @@ class ContractLCMTable(BaseTable):
             "contract_type",
             "provider",
             "active",
-            "tags",
             "actions",
         )
 
@@ -481,7 +506,7 @@ class CVELCMTable(StatusTableMixin, BaseTable):
                     {% endif %}""",
         verbose_name="Link",
     )
-    tags = TagColumn()
+    tags = TagColumn(url_name="plugins:nautobot_device_lifecycle_mgmt:cvelcm_list")
     actions = ButtonsColumn(CVELCM, buttons=("changelog", "edit", "delete"))
 
     class Meta(BaseTable.Meta):
@@ -530,7 +555,7 @@ class VulnerabilityLCMTable(StatusTableMixin, BaseTable):
     software = tables.LinkColumn()
     device = tables.LinkColumn()
     inventory_item = tables.LinkColumn(verbose_name="Inventory Item")
-    tags = TagColumn()
+    tags = TagColumn(url_name="plugins:nautobot_device_lifecycle_mgmt:vulnerabilitylcm_list")
     actions = ButtonsColumn(VulnerabilityLCM, buttons=("changelog", "edit", "delete"))
 
     class Meta(BaseTable.Meta):

--- a/nautobot_device_lifecycle_mgmt/tests/test_forms.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_forms.py
@@ -233,7 +233,11 @@ class ValidatedSoftwareLCMFormTest(TestCase):  # pylint: disable=no-member
         self.assertTrue(form.save())
 
     def test_tags_are_saved(self):
-        """Tags selected on the form must be persisted, not silently dropped."""
+        """Tags selected on the form must be persisted, not silently dropped.
+
+        ValidatedSoftwareLCM has no PrimaryObjectViewTestCase, so the generic create/edit tests that
+        assert tag persistence via `form_data` do not cover it.
+        """
         tag = Tag.objects.create(name="Validated Software Tag")
         tag.content_types.add(ContentType.objects.get_for_model(ValidatedSoftwareLCM))
         data = {
@@ -347,23 +351,6 @@ class CVELCMFormTest(TestCase):
         )
         self.assertTrue(form.is_valid())
         self.assertTrue(form.save())
-
-    def test_tags_are_saved(self):
-        """Tags selected on the form must be persisted, not silently dropped."""
-        tag = Tag.objects.create(name="CVE Tag")
-        tag.content_types.add(self.cve_ct)
-        form = CVELCMForm(
-            data={
-                "name": "CVE-2021-34700",
-                "published_date": "2021-09-23",
-                "link": "https://www.cvedetails.com/cve/CVE-2021-34700/",
-                "status": self.status,
-                "tags": [tag.pk],
-            }
-        )
-        self.assertTrue(form.is_valid(), form.errors)
-        cve = form.save()
-        self.assertEqual(list(cve.tags.values_list("name", flat=True)), ["CVE Tag"])
 
     def test_required_fields_missing(self):
         form = CVELCMForm(data={"name": "CVE-2022-0002"})

--- a/nautobot_device_lifecycle_mgmt/tests/test_forms.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_forms.py
@@ -12,10 +12,27 @@ from nautobot.dcim.models import (
     Platform,
     SoftwareVersion,
 )
-from nautobot.extras.models import Role, Status
+from nautobot.extras.models import Role, Status, Tag
 
-from nautobot_device_lifecycle_mgmt.forms import CVELCMForm, HardwareLCMForm, ValidatedSoftwareLCMForm
-from nautobot_device_lifecycle_mgmt.models import CVELCM
+from nautobot_device_lifecycle_mgmt.forms import (
+    ContractLCMBulkEditForm,
+    ContractLCMForm,
+    CVELCMBulkEditForm,
+    CVELCMForm,
+    HardwareLCMBulkEditForm,
+    HardwareLCMForm,
+    ValidatedSoftwareLCMBulkEditForm,
+    ValidatedSoftwareLCMForm,
+    VulnerabilityLCMBulkEditForm,
+    VulnerabilityLCMForm,
+)
+from nautobot_device_lifecycle_mgmt.models import (
+    CVELCM,
+    ContractLCM,
+    HardwareLCM,
+    ValidatedSoftwareLCM,
+    VulnerabilityLCM,
+)
 
 
 class HardwareLCMFormTest(TestCase):
@@ -215,6 +232,23 @@ class ValidatedSoftwareLCMFormTest(TestCase):  # pylint: disable=no-member
         self.assertTrue(form.is_valid())
         self.assertTrue(form.save())
 
+    def test_tags_are_saved(self):
+        """Tags selected on the form must be persisted, not silently dropped."""
+        tag = Tag.objects.create(name="Validated Software Tag")
+        tag.content_types.add(ContentType.objects.get_for_model(ValidatedSoftwareLCM))
+        data = {
+            "software": self.software,
+            "devices": [self.device_1],
+            "start": "2021-06-06",
+            "end": "2023-08-31",
+            "preferred": False,
+            "tags": [tag.pk],
+        }
+        form = self.form_class(data)
+        self.assertTrue(form.is_valid(), form.errors)
+        validated_software = form.save()
+        self.assertEqual(list(validated_software.tags.values_list("name", flat=True)), ["Validated Software Tag"])
+
     def test_specifying_all_fields_w_device_type(self):
         data = {
             "software": self.software,
@@ -314,6 +348,23 @@ class CVELCMFormTest(TestCase):
         self.assertTrue(form.is_valid())
         self.assertTrue(form.save())
 
+    def test_tags_are_saved(self):
+        """Tags selected on the form must be persisted, not silently dropped."""
+        tag = Tag.objects.create(name="CVE Tag")
+        tag.content_types.add(self.cve_ct)
+        form = CVELCMForm(
+            data={
+                "name": "CVE-2021-34700",
+                "published_date": "2021-09-23",
+                "link": "https://www.cvedetails.com/cve/CVE-2021-34700/",
+                "status": self.status,
+                "tags": [tag.pk],
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        cve = form.save()
+        self.assertEqual(list(cve.tags.values_list("name", flat=True)), ["CVE Tag"])
+
     def test_required_fields_missing(self):
         form = CVELCMForm(data={"name": "CVE-2022-0002"})
         self.assertFalse(form.is_valid())
@@ -324,3 +375,58 @@ class CVELCMFormTest(TestCase):
             },
             form.errors,
         )
+
+
+class TaggableModelFormTest(TestCase):
+    """Test tag support on the create/edit forms of taggable Lifecycle Management models."""
+
+    form_classes = (
+        HardwareLCMForm,
+        ValidatedSoftwareLCMForm,
+        ContractLCMForm,
+        CVELCMForm,
+        VulnerabilityLCMForm,
+    )
+
+    def test_tags_field_present(self):
+        """The tags widget must be offered by the form."""
+        for form_class in self.form_classes:
+            with self.subTest(form=form_class.__name__):
+                self.assertIn("tags", form_class().fields)
+
+    def test_tags_included_in_meta_fields(self):
+        """Django's _save_m2m() drops tags unless "tags" is listed in an explicit Meta.fields."""
+        for form_class in self.form_classes:
+            with self.subTest(form=form_class.__name__):
+                meta_fields = form_class._meta.fields  # pylint: disable=protected-access, no-member
+                # ModelFormMetaclass normalizes `fields = "__all__"` to None, which saves every model field.
+                if meta_fields is not None:
+                    self.assertIn("tags", meta_fields)
+
+
+class TaggableModelBulkEditFormTest(TestCase):
+    """Test tag support on the bulk edit forms of taggable Lifecycle Management models."""
+
+    forms_and_models = (
+        (HardwareLCMBulkEditForm, HardwareLCM),
+        (ValidatedSoftwareLCMBulkEditForm, ValidatedSoftwareLCM),
+        (ContractLCMBulkEditForm, ContractLCM),
+        (CVELCMBulkEditForm, CVELCM),
+        (VulnerabilityLCMBulkEditForm, VulnerabilityLCM),
+    )
+
+    def test_add_and_remove_tags_fields_present(self):
+        """The bulk edit view only applies tags through the `add_tags` and `remove_tags` fields."""
+        for form_class, model in self.forms_and_models:
+            with self.subTest(form=form_class.__name__):
+                form = form_class(model)
+                self.assertIn("add_tags", form.fields)
+                self.assertIn("remove_tags", form.fields)
+
+    def test_tags_is_not_a_bulk_edit_field(self):
+        """A plain `tags` field is silently ignored by the bulk edit view, so it must not be offered."""
+        for form_class, model in self.forms_and_models:
+            with self.subTest(form=form_class.__name__):
+                form = form_class(model)
+                self.assertNotIn("tags", form.fields)
+                self.assertNotIn("tags", form.nullable_fields)

--- a/nautobot_device_lifecycle_mgmt/tests/test_tables.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_tables.py
@@ -1,0 +1,49 @@
+"""Test tables."""
+
+from django.test import TestCase
+from django.urls import reverse
+
+from nautobot_device_lifecycle_mgmt.tables import (
+    ContractLCMTable,
+    CVELCMTable,
+    HardwareLCMTable,
+    ValidatedSoftwareLCMTable,
+    VulnerabilityLCMTable,
+)
+
+
+# `base_columns` is added to each table by the django-tables2 metaclass, so pylint cannot see it.
+class TaggableModelTableTest(TestCase):
+    """Test the tags column on the list view tables of taggable Lifecycle Management models."""
+
+    table_classes = (
+        HardwareLCMTable,
+        ValidatedSoftwareLCMTable,
+        ContractLCMTable,
+        CVELCMTable,
+        VulnerabilityLCMTable,
+    )
+
+    def test_tags_column_is_available(self):
+        """The tags column must be selectable in the table configuration."""
+        for table_class in self.table_classes:
+            with self.subTest(table=table_class.__name__):
+                self.assertIn("tags", table_class.base_columns)  # pylint: disable=no-member
+
+    def test_tags_column_is_not_a_default_column(self):
+        """The tags column must be hidden until a user opts into it."""
+        for table_class in self.table_classes:
+            with self.subTest(table=table_class.__name__):
+                default_columns = getattr(table_class.Meta, "default_columns", [])
+                # Without default_columns nothing is hidden, so every column in `fields` shows by default.
+                self.assertTrue(default_columns, "default_columns must be set for tags to be hidden by default")
+                self.assertNotIn("tags", default_columns)
+
+    def test_tags_column_links_to_filtered_list_view(self):
+        """Tag badges link to the list view filtered by tag, so the column needs a reversible url_name."""
+        for table_class in self.table_classes:
+            with self.subTest(table=table_class.__name__):
+                tags_column = table_class.base_columns["tags"]  # pylint: disable=no-member
+                url_name = tags_column.extra_context.get("url_name")
+                self.assertIsNotNone(url_name)
+                self.assertTrue(reverse(url_name))

--- a/nautobot_device_lifecycle_mgmt/tests/test_views.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_views.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from nautobot.apps.testing import ViewTestCases
 from nautobot.dcim.models import DeviceType, Manufacturer
-from nautobot.extras.models import Status
+from nautobot.extras.models import Status, Tag
 from nautobot.users.models import ObjectPermission
 
 from nautobot_device_lifecycle_mgmt.models import (
@@ -50,10 +50,15 @@ class HardwareLCMViewTest(ViewTestCases.PrimaryObjectViewTestCase):
         HardwareLCM.objects.create(device_type=device_types[1], end_of_sale=datetime.date(2021, 4, 1))
         HardwareLCM.objects.create(device_type=device_types[2], end_of_sale=datetime.date(2021, 4, 1))
 
+        # Including tags in form_data makes the generic create/edit tests assert that they are persisted.
+        tag = Tag.objects.create(name="Hardware Notice Tag")
+        tag.content_types.add(ContentType.objects.get_for_model(HardwareLCM))
+
         cls.form_data = {
             "device_type": device_types[3].id,
             "end_of_sale": datetime.date(2021, 4, 1),
             "end_of_support": datetime.date(2024, 4, 1),
+            "tags": [tag.pk],
         }
         cls.csv_data = (
             "device_type,end_of_sale,end_of_support,end_of_sw_releases,end_of_security_patches,documentation_url",
@@ -239,10 +244,15 @@ class CVELCMViewTest(ViewTestCases.PrimaryObjectViewTestCase):
             "status": Status.objects.get_for_model(CVELCM).first().pk,
         }
 
+        # Including tags in form_data makes the generic create/edit tests assert that they are persisted.
+        tag = Tag.objects.create(name="CVE Tag")
+        tag.content_types.add(ContentType.objects.get_for_model(CVELCM))
+
         cls.form_data = {
             "name": "Test 1",
             "published_date": datetime.date(2022, 1, 1),
             "link": "https://www.cvedetails.com/cve/CVE-2022-0001/",
+            "tags": [tag.pk],
         }
 
     @skip("Not implemented")


### PR DESCRIPTION
This pull request adds robust tag support to the Lifecycle Management models, ensuring that tags are consistently handled across creation, editing, and bulk edit forms, as well as list views. It fixes issues where tags were silently dropped on certain forms, standardizes how tags are applied in bulk edits, and introduces a selectable tags column to relevant tables. Comprehensive tests are included to verify the correct behavior of tags in both forms and tables.

**Tag support in forms and bulk edit:**

* Added `TagsBulkEditFormMixin` to all applicable bulk edit forms (`HardwareLCMBulkEditForm`, `ValidatedSoftwareLCMBulkEditForm`, `ContractLCMBulkEditForm`, `CVELCMBulkEditForm`, `VulnerabilityLCMBulkEditForm`) to enable proper handling of tag addition and removal, and removed the ineffective `tags` field from these forms. [[1]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3R20) [[2]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3L99-R100) [[3]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3L219-R219) [[4]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3L613-R612) [[5]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3L790-L797) [[6]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3R887-L907)
* Ensured the `tags` field is explicitly included in the `Meta.fields` of all taggable create/edit forms, so that tags are persisted on save. [[1]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3R196) [[2]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3R780) [[3]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3L877-L878) [[4]](diffhunk://#diff-535cdb89a0b3761de8764be6f6765dc0b47b1144385ffb90294bd02af392a1a3L809)

**Fixes to tag persistence:**

* Fixed an issue where tags were silently discarded when creating or editing Validated Software, CVE, and Vulnerability objects due to omission from `Meta.fields`.

**Table and list view improvements:**

* Added a selectable (non-default) tags column to the Hardware Notice (`HardwareLCMTable`) and Validated Software (`ValidatedSoftwareLCMTable`) list views, and ensured all taggable tables have a tags column that links to the filtered list view. [[1]](diffhunk://#diff-59293acb26330da58460bd5230a1b7b95045b09de2fd9d25c0ccde5fd94ebe27R1-R3) [[2]](diffhunk://#diff-352078346e05a539873d619415c61d91611d05bef042d45a35f0a4be84407610R59-R78) [[3]](diffhunk://#diff-352078346e05a539873d619415c61d91611d05bef042d45a35f0a4be84407610R108-R125) [[4]](diffhunk://#diff-352078346e05a539873d619415c61d91611d05bef042d45a35f0a4be84407610L484-R509) [[5]](diffhunk://#diff-352078346e05a539873d619415c61d91611d05bef042d45a35f0a4be84407610L533-R558)
* Fixed the Contract list view so the tags column is hidden by default, matching other list views. [[1]](diffhunk://#diff-83733015d14bffe590d6f5ed6a767c4b78e08a055a65830952036c43db8c566bR1-R3) [[2]](diffhunk://#diff-352078346e05a539873d619415c61d91611d05bef042d45a35f0a4be84407610L430)

**Testing:**

* Added comprehensive tests to verify that tags are present on forms, included in `Meta.fields`, handled correctly in bulk edit forms, and that the tags column behaves as expected in tables. [[1]](diffhunk://#diff-82c83d58542d2a4e205533a2b4b668e200d7565d0f424dc46b78febecb0d66f6R235-R251) [[2]](diffhunk://#diff-82c83d58542d2a4e205533a2b4b668e200d7565d0f424dc46b78febecb0d66f6R351-R367) [[3]](diffhunk://#diff-82c83d58542d2a4e205533a2b4b668e200d7565d0f424dc46b78febecb0d66f6R378-R432) [[4]](diffhunk://#diff-bf95f2e1497740d75a022651324c46fce019f3ab8c05116c166b6b9b424bf954R1-R49)