### PR TITLE
Fix incorrect filters and sort column on list views

### DIFF
--- a/changes/565.fixed
+++ b/changes/565.fixed
@@ -1,0 +1,5 @@
+Fixed the `tag` filter form field on the CVE and Vulnerability list views. It was named `tag` while the corresponding filterset filter is `tags`, so the field could never bind and filtering by tag was rejected with "Invalid filters were specified".
+
+Fixed the missing `exclude_status` filter on `VulnerabilityLCMFilterSet`. The filter form offered the field but the filterset had no matching filter.
+
+Fixed a server error when sorting the Vulnerability list view by the Name column. `VulnerabilityLCM` has no `name` field - the label comes from `__str__` - so the column is no longer orderable.

--- a/changes/565.fixed
+++ b/changes/565.fixed
@@ -3,3 +3,7 @@ Fixed the `tag` filter form field on the CVE and Vulnerability list views. It wa
 Fixed the missing `exclude_status` filter on `VulnerabilityLCMFilterSet`. The filter form offered the field but the filterset had no matching filter.
 
 Fixed a server error when sorting the Vulnerability list view by the Name column. `VulnerabilityLCM` has no `name` field - the label comes from `__str__` - so the column is no longer orderable.
+
+Fixed the Devices, Inventory Items and Object Tags filters on the Validated Software list view, which rejected the value selected in the UI with "Select a valid choice. <uuid> is not one of the available choices". The filters on `ValidatedSoftwareLCMFilterSet` matched on the natural key only, while the filter form submitted a primary key. All six related-object filters there are now `NaturalKeyOrPKMultipleChoiceFilter` and accept either a primary key or a natural key. Filters whose target has a non-unique natural key (`devices`, `inventory_items`, `device_types`) use `prefers_id=True`, so the UI submits primary keys while the natural key still works as a query parameter.
+
+Fixed the Status filter on the Contract list view. `ContractLCMFilterSet` was missing `StatusModelFilterSetMixin`, so the auto-generated filter matched on primary key while the filter form submitted the status name.

--- a/nautobot_device_lifecycle_mgmt/filters.py
+++ b/nautobot_device_lifecycle_mgmt/filters.py
@@ -5,7 +5,13 @@ import datetime
 
 import django_filters
 from django.db.models import Q
-from nautobot.apps.filters import NautobotFilterSet, SearchFilter, StatusFilter, StatusModelFilterSetMixin
+from nautobot.apps.filters import (
+    NaturalKeyOrPKMultipleChoiceFilter,
+    NautobotFilterSet,
+    SearchFilter,
+    StatusFilter,
+    StatusModelFilterSetMixin,
+)
 from nautobot.dcim.models import Device, DeviceType, InventoryItem, Location, Manufacturer, Platform, SoftwareVersion
 from nautobot.extras.models import Role, Status, Tag
 from nautobot.tenancy.models import Tenant
@@ -303,66 +309,71 @@ class ValidatedSoftwareLCMFilterSet(NautobotFilterSet):
         queryset=Device.objects.all(),
         label="Devices",
     )
-    devices = django_filters.ModelMultipleChoiceFilter(
-        field_name="devices__name",
+    # `prefers_id=True` where the target's natural key is not globally unique: the filter form
+    # submits PKs, while the natural key still works as a query parameter.
+    devices = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="devices",
         queryset=Device.objects.all(),
         to_field_name="name",
-        label="Devices (name)",
+        prefers_id=True,
+        label="Devices (name or ID)",
     )
     device_types_id = django_filters.ModelMultipleChoiceFilter(
         field_name="device_types",
         queryset=DeviceType.objects.all(),
         label="Device Types",
     )
-    device_types = django_filters.ModelMultipleChoiceFilter(
-        field_name="device_types__model",
+    device_types = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="device_types",
         queryset=DeviceType.objects.all(),
         to_field_name="model",
-        label="Device Types (model)",
+        prefers_id=True,
+        label="Device Types (model or ID)",
     )
     device_tenants_id = django_filters.ModelMultipleChoiceFilter(
         field_name="device_tenants",
         queryset=Tenant.objects.all(),
         label="Tenant",
     )
-    device_tenants = django_filters.ModelMultipleChoiceFilter(
-        field_name="device_tenants__name",
+    device_tenants = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="device_tenants",
         queryset=Tenant.objects.all(),
         to_field_name="name",
-        label="Tenant (name)",
+        label="Tenant (name or ID)",
     )
     device_roles_id = django_filters.ModelMultipleChoiceFilter(
         field_name="device_roles",
         queryset=Role.objects.all(),
         label="Device Roles",
     )
-    device_roles = django_filters.ModelMultipleChoiceFilter(
-        field_name="device_roles__name",
+    device_roles = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="device_roles",
         queryset=Role.objects.all(),
         to_field_name="name",
-        label="Device Roles (name)",
+        label="Device Roles (name or ID)",
     )
     inventory_items_id = django_filters.ModelMultipleChoiceFilter(
         field_name="inventory_items",
         queryset=InventoryItem.objects.all(),
         label="Inventory Items",
     )
-    inventory_items = django_filters.ModelMultipleChoiceFilter(
-        field_name="inventory_items__name",
+    inventory_items = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="inventory_items",
         queryset=InventoryItem.objects.all(),
         to_field_name="name",
-        label="Inventory Items (name)",
+        prefers_id=True,
+        label="Inventory Items (name or ID)",
     )
     object_tags_id = django_filters.ModelMultipleChoiceFilter(
         field_name="object_tags",
         queryset=Tag.objects.all(),
         label="Object Tags",
     )
-    object_tags = django_filters.ModelMultipleChoiceFilter(
-        field_name="object_tags__name",
+    object_tags = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="object_tags",
         queryset=Tag.objects.all(),
         to_field_name="name",
-        label="Object Tags (name)",
+        label="Object Tags (name or ID)",
     )
     device_name = django_filters.CharFilter(method="device", label="Device Name")
     device_id = django_filters.CharFilter(method="device", label="Device ID")
@@ -798,7 +809,7 @@ class InventoryItemSoftwareValidationResultFilterSet(NautobotFilterSet):
         return queryset
 
 
-class ContractLCMFilterSet(NautobotFilterSet):
+class ContractLCMFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
     """Filter for ContractLCM."""
 
     q = SearchFilter(

--- a/nautobot_device_lifecycle_mgmt/filters.py
+++ b/nautobot_device_lifecycle_mgmt/filters.py
@@ -1021,6 +1021,7 @@ class VulnerabilityLCMFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):  
     cve__published_date__gte = django_filters.DateFilter(field_name="cve__published_date", lookup_expr="gte")  # pylint: disable=nb-warn-dunder-filter-field # TODO 3.0: Remove this filter when Nautobot adds it automatically
     cve__published_date__lte = django_filters.DateFilter(field_name="cve__published_date", lookup_expr="lte")  # pylint: disable=nb-warn-dunder-filter-field # TODO 3.0: Remove this filter when Nautobot adds it automatically
     cve__severity = django_filters.ChoiceFilter(field_name="cve__severity", choices=CVESeverityChoices)  # pylint: disable=nb-warn-dunder-filter-field
+    exclude_status = StatusFilter(field_name="status", exclude=True)
 
     class Meta:
         """Meta attributes for filter."""

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -898,7 +898,7 @@ class CVELCMFilterForm(NautobotFilterForm):
         query_params={"content_types": model._meta.label_lower},  # pylint: disable=protected-access, no-member
         to_field_name="name",
     )
-    tag = TagFilterField(model)
+    tags = TagFilterField(model)
 
     class Meta:
         """Meta attributes."""
@@ -978,7 +978,7 @@ class VulnerabilityLCMFilterForm(NautobotFilterForm):
         query_params={"content_types": model._meta.label_lower},  # pylint: disable=protected-access, no-member
         to_field_name="name",
     )
-    tag = TagFilterField(model)
+    tags = TagFilterField(model)
 
     class Meta:
         """Meta attributes."""

--- a/nautobot_device_lifecycle_mgmt/forms.py
+++ b/nautobot_device_lifecycle_mgmt/forms.py
@@ -319,6 +319,9 @@ class ValidatedSoftwareLCMFilterForm(NautobotFilterForm):
         help_text="Search for start or end date of validity.",
     )
     software = DynamicModelChoiceField(required=False, queryset=SoftwareVersion.objects.all())
+    # Device, InventoryItem and DeviceType have non-unique natural keys, so their filters set
+    # `prefers_id=True` and these fields submit PKs. The remaining fields target models with a
+    # unique `name` and submit that instead.
     devices = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         required=False,
@@ -330,7 +333,6 @@ class ValidatedSoftwareLCMFilterForm(NautobotFilterForm):
     )
     device_types = DynamicModelMultipleChoiceField(
         queryset=DeviceType.objects.all(),
-        to_field_name="model",
         required=False,
     )
     device_roles = DynamicModelMultipleChoiceField(
@@ -345,6 +347,7 @@ class ValidatedSoftwareLCMFilterForm(NautobotFilterForm):
     )
     object_tags = DynamicModelMultipleChoiceField(
         queryset=Tag.objects.all(),
+        to_field_name="name",
         required=False,
     )
     start_before = forms.DateField(label="Valid Since Date Before", required=False, widget=DatePicker())

--- a/nautobot_device_lifecycle_mgmt/tables.py
+++ b/nautobot_device_lifecycle_mgmt/tables.py
@@ -563,8 +563,13 @@ class VulnerabilityLCMTable(StatusTableMixin, BaseTable):
 
     model = VulnerabilityLCM
     pk = ToggleColumn()
+    # VulnerabilityLCM has no `name` field; the label comes from __str__, so this column
+    # cannot be ordered by the database.
     name = tables.LinkColumn(
-        "plugins:nautobot_device_lifecycle_mgmt:vulnerabilitylcm", text=lambda record: record, args=[A("pk")]
+        "plugins:nautobot_device_lifecycle_mgmt:vulnerabilitylcm",
+        text=lambda record: record,
+        args=[A("pk")],
+        orderable=False,
     )
     cve = tables.LinkColumn(verbose_name="CVE")
     software = tables.LinkColumn()

--- a/nautobot_device_lifecycle_mgmt/tests/test_filters.py
+++ b/nautobot_device_lifecycle_mgmt/tests/test_filters.py
@@ -7,8 +7,17 @@ from unittest import skip
 import time_machine
 from django.contrib.contenttypes.models import ContentType
 from nautobot.apps.testing import FilterTestCases
-from nautobot.dcim.models import Device, DeviceType, Location, LocationType, Manufacturer, Platform, SoftwareVersion
-from nautobot.extras.models import Role, Status
+from nautobot.dcim.models import (
+    Device,
+    DeviceType,
+    InventoryItem,
+    Location,
+    LocationType,
+    Manufacturer,
+    Platform,
+    SoftwareVersion,
+)
+from nautobot.extras.models import Role, Status, Tag
 from nautobot.tenancy.models import Tenant
 
 from nautobot_device_lifecycle_mgmt.choices import ContractTypeChoices, CurrencyChoices, CVESeverityChoices
@@ -616,6 +625,28 @@ class ValidatedSoftwareLCMFilterSetTestCase(FilterTestCases.FilterTestCase):
 
         manufacturer, _ = Manufacturer.objects.get_or_create(name="Cisco")
         device_type, _ = DeviceType.objects.get_or_create(manufacturer=manufacturer, model="ASR-1000")
+        cls.device_type = device_type
+        cls.device_role_router = device_role_router
+
+        # Objects for the devices / inventory_items / object_tags filters. Names deliberately avoid
+        # digits, so they cannot match the date values used by the `q` filter tests.
+        active_status.content_types.add(ContentType.objects.get_for_model(Device))
+        active_status.content_types.add(ContentType.objects.get_for_model(Location))
+        location_type, _ = LocationType.objects.get_or_create(name="Site")
+        location_type.content_types.add(ContentType.objects.get_for_model(Device))
+        location, _ = Location.objects.get_or_create(
+            name="Filter Test Site", location_type=location_type, defaults={"status": active_status}
+        )
+        cls.device = Device.objects.create(
+            name="filter-test-device",
+            device_type=device_type,
+            role=device_role_router,
+            location=location,
+            status=active_status,
+        )
+        cls.inventory_item = InventoryItem.objects.create(device=cls.device, name="filter-test-item")
+        cls.object_tag = Tag.objects.create(name="filter-test-tag")
+        cls.object_tag.content_types.add(ContentType.objects.get_for_model(ValidatedSoftwareLCM))
 
         validated_software = ValidatedSoftwareLCM(
             software=cls.softwares[0],
@@ -625,6 +656,9 @@ class ValidatedSoftwareLCMFilterSetTestCase(FilterTestCases.FilterTestCase):
         )
         validated_software.save()
         validated_software.device_types.set([device_type.pk])
+        validated_software.devices.set([cls.device])
+        validated_software.inventory_items.set([cls.inventory_item])
+        validated_software.object_tags.set([cls.object_tag])
 
         validated_software = ValidatedSoftwareLCM(
             software=cls.softwares[1],
@@ -664,6 +698,46 @@ class ValidatedSoftwareLCMFilterSetTestCase(FilterTestCases.FilterTestCase):
     def test_device_tenants(self):
         """Test device_tenants filter."""
         params = {"device_tenants": ["Tenant A"]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    # The filters below are NaturalKeyOrPKMultipleChoiceFilter, so each must accept both a primary
+    # key and a natural key. The PK path is what the filter form submits from the UI.
+    def test_devices(self):
+        """Test devices filter by PK and by name."""
+        for value in (self.device.pk, self.device.name):
+            with self.subTest(value=value):
+                params = {"devices": [value]}
+                self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_inventory_items(self):
+        """Test inventory_items filter by PK and by name."""
+        for value in (self.inventory_item.pk, self.inventory_item.name):
+            with self.subTest(value=value):
+                params = {"inventory_items": [value]}
+                self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_object_tags(self):
+        """Test object_tags filter by PK and by name."""
+        for value in (self.object_tag.pk, self.object_tag.name):
+            with self.subTest(value=value):
+                params = {"object_tags": [value]}
+                self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_device_types(self):
+        """Test device_types filter by PK and by model."""
+        for value in (self.device_type.pk, self.device_type.model):
+            with self.subTest(value=value):
+                params = {"device_types": [value]}
+                self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_device_roles_pk(self):
+        """Test device_roles filter by PK."""
+        params = {"device_roles": [self.device_role_router.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_device_tenants_pk(self):
+        """Test device_tenants filter by PK."""
+        params = {"device_tenants": [Tenant.objects.get(name="Tenant A").pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_software(self):


### PR DESCRIPTION
### Fix incorrect filters and sort columns on list views
Addresses part of #565.

### What was broken

**Validated Software** — selecting a device, inventory item or tag in the filter failed with "Select a valid choice. <uuid> is not one of the available choices". The filters matched on natural key only; the form submitted a PK.
**Contract** — Status filter failed with "'Active' is not a valid UUID". ContractLCMFilterSet was missing StatusModelFilterSetMixin, so status auto-generated as PK-only while the form mixin submits the name.
**CVE / Vulnerability** — the filter forms declared tag (singular) but the filterset filter is tags, so the field could never bind.
**Vulnerability** — exclude_status existed on the form but had no filter behind it.
**Vulnerability** — sorting by Name raised Cannot resolve keyword 'name'; the model has no name field, its label comes from __str__.

### Changes

- Converted all six related-object filters on ValidatedSoftwareLCMFilterSet to NaturalKeyOrPKMultipleChoiceFilter (the class #596 calls for), so each accepts a PK or a natural key. field_name now points at the relation instead of traversing to __name. devices, inventory_items and device_types use prefers_id=True because their natural keys aren't globally unique; their form fields drop to_field_name to match.

- Added StatusModelFilterSetMixin to ContractLCMFilterSet and exclude_status to VulnerabilityLCMFilterSet.

- Renamed tag → tags on the CVE and Vulnerability filter forms.

- Marked VulnerabilityLCMTable.name as orderable=False, matching the other DLM tables.

- Added devices/inventory items/tags to the ValidatedSoftware test fixture (it had none) plus six tests covering both the PK and natural-key path.

### Notes for reviewers

No cost fix here, and none needed. unsupported field type FloatField came from the reproduction gist's own fallback branch, not Nautobot. The gist added FloatField handling two days after the issue was filed. Some other entries on that list are stale for the same reason.

A clean gist run isn't proof on Nautobot 3.1.x. It greps the response for "Invalid filters were specified", which is no longer rendered — it reported PASS for all three ValidatedSoftware filters that were actually broken. Verified here by feeding each form field's real submitted value (prepare_value) into its filterset instead.

*_id twins retained. Redundant now, but removing them breaks the REST API — that belongs in #596.
prefers_id and NaturalKeyOrPKMultipleChoiceFilter exist in all supported Nautobot versions, and the latter is already used in filter_extensions.py.

678 tests pass (was 672), ruff clean, pylint 10.00/10.

<!--
    Thank you for your interest in contributing to Device Lifecycle Management! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #565 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
