### PR TITLE
NAPPS-1815: Rename Device Lifecycle Management nav bar entry to Lifecycle

### DIFF
--- a/changes/+622.changed
+++ b/changes/+622.changed
@@ -1,0 +1,1 @@
+Renamed the navigation menu tab from "Device Lifecycle" to "Lifecycle".

--- a/nautobot_device_lifecycle_mgmt/navigation.py
+++ b/nautobot_device_lifecycle_mgmt/navigation.py
@@ -10,7 +10,7 @@ from nautobot.apps.ui import (
 
 menu_items = (
     NavMenuTab(
-        name="Device Lifecycle",
+        name="Lifecycle",
         icon=NavigationIconChoices.DEVICE_LIFECYCLE,
         weight=NavigationWeightChoices.DEVICE_LIFECYCLE,
         groups=(


### PR DESCRIPTION
# Closes: #NAPPS-1815

## What's Changed

Renames the app's navigation menu tab from "Device Lifecycle" to "Lifecycle", ahead of the Lifecycle app release. Only the displayed tab label changes, the icon, weight, groups, links and permissions in `nautobot_device_lifecycle_mgmt/navigation.py` are untouched, so no URLs or permissions are affected.

- `nautobot_device_lifecycle_mgmt/navigation.py`: `NavMenuTab(name=...)` is now `"Lifecycle"`.
- `changes/+622.changed`: changelog fragment under "Changed".

### Screenshot
<img width="482" height="813" alt="image" src="https://github.com/user-attachments/assets/7374190c-fc25-4122-a92f-0879825f10b0" />


### Note on the base branch

This branch was cut from `next-3.1`, so the PR currently also carries the pre existing "bare minimum support for nautobot 3.1" commit, which is not part of this change:

- `pyproject.toml`: adds the Python 3.14 classifier, widens `python` to `>=3.10,<3.15`, and points `nautobot` at the `next` git branch (with a TODO to restore `>=3.1.0,<4.0.0` after 3.1.0 ships).
- `poetry.lock`: regenerated for the above.

Either retarget the PR base to `next-3.1` or rebase onto `develop` so the diff shows only the navigation rename.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
